### PR TITLE
refact :: 공지 등록 날짜 형식 변경

### DIFF
--- a/Projects/Core/Sources/Util/UI/Calendar+.swift
+++ b/Projects/Core/Sources/Util/UI/Calendar+.swift
@@ -1,0 +1,9 @@
+import UIKit
+
+public extension Calendar {
+    func getDateGap(from: Date, to: Date? = Date()) -> Int {
+        let fromDate = from.onlyDate
+        let toDate = to?.onlyDate ?? Date()
+        return self.dateComponents([.day], from: fromDate, to: toDate).day ?? 0
+    }
+}

--- a/Projects/Core/Sources/Util/UI/Date+.swift
+++ b/Projects/Core/Sources/Util/UI/Date+.swift
@@ -1,6 +1,11 @@
 import Foundation
 
 public extension Date {
+    var onlyDate: Date {
+        let component = Calendar.current.dateComponents([.year, .month, .day], from: self)
+        return Calendar.current.date(from: component) ?? Date()
+    }
+
     func toString(type: DateFormatIndicated) -> String {
         let dateFormatter = DateFormatter()
         dateFormatter.dateFormat = type.rawValue

--- a/Projects/Presentation/Sources/Scene/Notice/Cell/NoticeCollectionViewCell.swift
+++ b/Projects/Presentation/Sources/Scene/Notice/Cell/NoticeCollectionViewCell.swift
@@ -46,10 +46,7 @@ public class NoticeCollectionViewCell: BaseCollectionViewCell<NoticeListEntityEl
 
         let dateGap = Calendar.current.getDateGap(from: model.createAt.toDate(type: .fullDate))
         self.daysAgoLabel.text = "\(dateGap == 0 ? "오늘" : "\(dateGap)일 전")"
-
-        if model.createAt == Date().toString(type: .fullDate) {
-            self.newNoticeIcon.isHidden = false
-        }
+        self.newNoticeIcon.isHidden = dateGap != 0
     }
 
     public override func layout() {

--- a/Projects/Presentation/Sources/Scene/Notice/Cell/NoticeCollectionViewCell.swift
+++ b/Projects/Presentation/Sources/Scene/Notice/Cell/NoticeCollectionViewCell.swift
@@ -43,7 +43,10 @@ public class NoticeCollectionViewCell: BaseCollectionViewCell<NoticeListEntityEl
 
         self.id = model.id
         self.titleLabel.text = model.title
-        self.daysAgoLabel.text = model.createAt
+
+        let dateGap = Calendar.current.getDateGap(from: model.createAt.toDate(type: .fullDate))
+        self.daysAgoLabel.text = "\(dateGap == 0 ? "오늘" : "\(dateGap)일 전")"
+
         if model.createAt == Date().toString(type: .fullDate) {
             self.newNoticeIcon.isHidden = false
         }
@@ -65,7 +68,7 @@ public class NoticeCollectionViewCell: BaseCollectionViewCell<NoticeListEntityEl
             $0.leading.equalTo(noticeImageView.snp.trailing).offset(24)
         }
         newNoticeIcon.snp.makeConstraints {
-            $0.top.equalTo(titleStackView.snp.top).offset(2.5)
+            $0.top.equalTo(titleStackView.snp.top).offset(2)
             $0.leading.equalTo(titleStackView.snp.trailing).offset(4)
         }
     }


### PR DESCRIPTION
## 개요
* 공지 등록 날짜 형식 변경
## 작업사항
* 공지 등록 날짜 형식 변경
## UI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- 알림 화면에서 날짜 차이를 직관적으로 표시하여, 오늘은 "오늘"로, 경과된 날짜는 "X일 전"으로 보여줍니다.
	- 날짜 정보를 정확히 추출하여 사용자에게 올바른 날짜 표기를 제공합니다.
	- 두 날짜 간의 차이를 계산하는 기능이 추가되었습니다.
- **Style**
	- 알림 아이콘의 수직 위치가 미세하게 조정되어 레이아웃이 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->