### PR TITLE
feat :: [#118] SchoolMealView Calendar shadow 적용

### DIFF
--- a/Projects/Modules/DesignSystem/Sources/Component/Calendar/PiCKCalendarView.swift
+++ b/Projects/Modules/DesignSystem/Sources/Component/Calendar/PiCKCalendarView.swift
@@ -51,7 +51,7 @@ public class PiCKCalendarView: BaseView, FSCalendarDelegate, FSCalendarDataSourc
     }
 
     private lazy var calendarView = FSCalendar().then {
-        $0.backgroundColor = .background
+        $0.backgroundColor = .clear
 
         $0.calendarHeaderView.isHidden = true
         $0.locale = Locale(identifier: "ko_KR")

--- a/Projects/Modules/DesignSystem/Sources/Component/PickerView/PiCKPickerView.swift
+++ b/Projects/Modules/DesignSystem/Sources/Component/PickerView/PiCKPickerView.swift
@@ -5,12 +5,12 @@ import RxCocoa
 
 import Core
 
-protocol PiCKPickerViewDelegate: AnyObject {
+public protocol PiCKPickerViewDelegate: AnyObject {
     func pickerViewDidChangeValue(_ pickerView: PiCKPickerView, type: PickerTimeType, value: Int)
 }
 
 public class PiCKPickerView: UIPickerView, UIPickerViewDelegate, UIPickerViewDataSource {
-    private weak var pickerDelegate: PiCKPickerViewDelegate?
+    public weak var pickerDelegate: PiCKPickerViewDelegate?
     private var pickerTimeType: PickerTimeType = .hour
 
     public var periodText = BehaviorRelay<Int>(value: 1)

--- a/Projects/Presentation/Sources/Scene/SchoolMeal/SchoolMealViewController.swift
+++ b/Projects/Presentation/Sources/Scene/SchoolMeal/SchoolMealViewController.swift
@@ -23,7 +23,7 @@ public class SchoolMealViewController: BaseViewController<SchoolMealViewModel> {
     private lazy var calendarShadowView = UIView().then {
         $0.layer.shadowOpacity = 0.25
         $0.layer.shadowOffset = CGSize(width: 0, height: 5)
-        $0.layer.shadowRadius = 20
+        $0.layer.shadowRadius = 10
         $0.layer.cornerRadius = 20
         $0.backgroundColor = .background
     }

--- a/Projects/Presentation/Sources/Scene/SchoolMeal/SchoolMealViewController.swift
+++ b/Projects/Presentation/Sources/Scene/SchoolMeal/SchoolMealViewController.swift
@@ -107,6 +107,7 @@ public class SchoolMealViewController: BaseViewController<SchoolMealViewModel> {
             $0.leading.trailing.equalToSuperview()
         }
         calendarShadowView.snp.makeConstraints {
+            $0.top.equalToSuperview()
             $0.bottom.equalTo(dateLabel.snp.top).offset(-28)
             $0.leading.trailing.equalToSuperview()
         }

--- a/Projects/Presentation/Sources/Scene/SchoolMeal/SchoolMealViewController.swift
+++ b/Projects/Presentation/Sources/Scene/SchoolMeal/SchoolMealViewController.swift
@@ -20,6 +20,13 @@ public class SchoolMealViewController: BaseViewController<SchoolMealViewModel> {
             self.loadSchoolMeal(date: date)
         }
     )
+    private lazy var calendarShadowView = UIView().then {
+        $0.layer.shadowOpacity = 0.25
+        $0.layer.shadowOffset = CGSize(width: 0, height: 5)
+        $0.layer.shadowRadius = 20
+        $0.layer.cornerRadius = 20
+        $0.backgroundColor = .background
+    }
     private lazy var dateLabel = PiCKLabel(
         text: "오늘 \(todayDate.toString(type: .monthAndDayKor))",
         textColor: .modeBlack,
@@ -87,6 +94,7 @@ public class SchoolMealViewController: BaseViewController<SchoolMealViewModel> {
 
     public override func addView() {
         [
+            calendarShadowView,
             navigationBar,
             schoolMealCalendarView,
             dateLabel,
@@ -96,6 +104,10 @@ public class SchoolMealViewController: BaseViewController<SchoolMealViewModel> {
     public override func setLayout() {
         navigationBar.snp.makeConstraints {
             $0.top.equalTo(view.safeAreaLayoutGuide)
+            $0.leading.trailing.equalToSuperview()
+        }
+        calendarShadowView.snp.makeConstraints {
+            $0.bottom.equalTo(dateLabel.snp.top).offset(-28)
             $0.leading.trailing.equalToSuperview()
         }
         schoolMealCalendarView.snp.makeConstraints {


### PR DESCRIPTION
## 개요
SchoolMealView Calendar shadow 적용

## 작업사항
- calendarShadowView를 만들어 schoolMealCalendarView 아래에 둠
- calendarShadowView가 가려지지 않도록 schoolMealCalendarView의 backgroundColor를 .clear로 변경

## UI
<img src="https://github.com/user-attachments/assets/4511f020-cc12-4057-8057-6e95db3bf70a" width=150>




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
  - 학교 급식 화면 상단에 그림자 효과가 추가되어 시각적 구분이 향상되었습니다.

- **스타일**
  - 캘린더 뷰의 배경색이 투명하게 변경되어 디자인이 개선되었습니다.

- **문서화**
  - PiCKPickerView의 delegate 프로토콜과 프로퍼티가 외부 모듈에서 사용할 수 있도록 공개되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->