### PR TITLE
refact :: [#172] 홈 리팩토링 및 전체적인 네이밍 수정

### DIFF
--- a/Projects/Core/Sources/Util/Enum/OutingType.swift
+++ b/Projects/Core/Sources/Util/Enum/OutingType.swift
@@ -5,3 +5,25 @@ public enum OutingType: String, Codable {
     case earlyReturn = "EARLY_RETURN"
     case classroom = "CLASSROOM"
 }
+
+extension OutingType {
+    public var toExplainText: String {
+        switch self {
+        case .application:
+            return "외출 수락 대기 중입니다"
+        case .earlyReturn:
+            return "조기귀가 수락 대기 중입니다"
+        case .classroom:
+            return "교실 이동 수락 대기 중입니다"
+        }
+    }
+
+    public var toPassText: String {
+        switch self {
+        case .application, .earlyReturn:
+            return "외출증 보기"
+        case .classroom:
+            return "돌아가기"
+        }
+    }
+}

--- a/Projects/Data/Sources/DTO/Outing/OutingPassDTO.swift
+++ b/Projects/Data/Sources/DTO/Outing/OutingPassDTO.swift
@@ -8,8 +8,7 @@ public struct OutingPassDTO: Decodable {
     let teacherName: String
     let start: String?
     let end: String?
-    let reason: String
-    let schoolNum: Int?
+    let reason: String?
     let grade: Int?
     let classNum: Int?
     let num: Int?
@@ -19,7 +18,6 @@ public struct OutingPassDTO: Decodable {
         case start, end, reason, type, grade, num
         case userName = "user_name"
         case teacherName = "teacher_name"
-        case schoolNum = "school_num"
         case classNum = "class_num"
     }
 }
@@ -28,14 +26,10 @@ extension OutingPassDTO {
     func toDomain() -> OutingPassEntity {
         return .init(
             userName: userName,
-            teacherName: teacherName,
-            start: start,
-            end: end,
-            reason: reason,
-            schoolNum: schoolNum,
-            grade: grade,
-            classNum: classNum,
-            num: num,
+            teacherName: "\(teacherName) 선생님",
+            time: "\(start ?? "") ~ \(end ?? "")",
+            reason: reason ?? "",
+            gcn: "\(grade ?? 0)학년 \(classNum ?? 0)반 \(num ?? 0)번",
             type: type
         )
     }

--- a/Projects/Data/Sources/DTO/Profile/SimpleProfileDTO.swift
+++ b/Projects/Data/Sources/DTO/Profile/SimpleProfileDTO.swift
@@ -20,9 +20,7 @@ extension SimpleProfileDTO {
     func toDomain() -> SimpleProfileEntity {
         return .init(
             name: name,
-            grade: grade,
-            classNum: classNum,
-            num: num,
+            gcn: "\(grade)학년 \(classNum)반 \(num)번",
             profile: profile
         )
     }

--- a/Projects/Domain/Sources/Entity/Outing/OutingPassEntity.swift
+++ b/Projects/Domain/Sources/Entity/Outing/OutingPassEntity.swift
@@ -5,36 +5,24 @@ import Core
 public struct OutingPassEntity {
     public let userName: String
     public let teacherName: String
-    public let start: String?
-    public let end: String?
-    public let reason: String
-    public let schoolNum: Int?
-    public let grade: Int?
-    public let classNum: Int?
-    public let num: Int?
+    public let time: String?
+    public let reason: String?
+    public let gcn: String?
     public let type: OutingType.RawValue
 
     public init(
         userName: String,
         teacherName: String,
-        start: String?,
-        end: String?,
-        reason: String,
-        schoolNum: Int?,
-        grade: Int?,
-        classNum: Int?,
-        num: Int?,
+        time: String,
+        reason: String?,
+        gcn: String?,
         type: OutingType.RawValue
     ) {
         self.userName = userName
         self.teacherName = teacherName
-        self.start = start
-        self.end = end
+        self.time = time
         self.reason = reason
-        self.schoolNum = schoolNum
-        self.grade = grade
-        self.classNum = classNum
-        self.num = num
+        self.gcn = gcn
         self.type = type
     }
 }

--- a/Projects/Domain/Sources/Entity/Profile/SimpleProfileEntity.swift
+++ b/Projects/Domain/Sources/Entity/Profile/SimpleProfileEntity.swift
@@ -2,22 +2,16 @@ import Foundation
 
 public struct SimpleProfileEntity {
     public let name: String
-    public let grade: Int
-    public let classNum: Int
-    public let num: Int
+    public let gcn: String
     public let profile: String?
 
     public init(
         name: String,
-        grade: Int,
-        classNum: Int,
-        num: Int,
+        gcn: String,
         profile: String?
     ) {
         self.name = name
-        self.grade = grade
-        self.classNum = classNum
-        self.num = num
+        self.gcn = gcn
         self.profile = profile
     }
 

--- a/Projects/Modules/DesignSystem/Sources/Component/Alert/PiCKAlert.swift
+++ b/Projects/Modules/DesignSystem/Sources/Component/Alert/PiCKAlert.swift
@@ -16,7 +16,7 @@ public enum PiCKAlertType {
 public class PiCKAlert: UIViewController {
     private let disposeBag = DisposeBag()
 
-    public var clickAction: () -> Void
+    public var actionOnTap: () -> Void
 
     private let backgroundView = UIView().then {
         $0.backgroundColor = .background
@@ -67,14 +67,14 @@ public class PiCKAlert: UIViewController {
         titleText: String,
         explainText: String,
         type: PiCKAlertType,
-        clickLogout: @escaping () -> Void
+        actionOnTap: @escaping () -> Void
     ) {
         self.titleLabel.text = titleText
         self.explainLabel.text = explainText
         if type == .positive {
             cancelButton.isHidden = true
         }
-        self.clickAction = clickLogout
+        self.actionOnTap = actionOnTap
         super.init(nibName: nil, bundle: nil)
         self.modalTransitionStyle = .crossDissolve
         self.modalPresentationStyle = .overFullScreen
@@ -105,7 +105,7 @@ public class PiCKAlert: UIViewController {
         confirmButton.rx.tap
             .bind { [weak self] in
                 self?.dismiss(animated: true) {
-                    self?.clickAction()
+                    self?.actionOnTap()
                 }
             }.disposed(by: disposeBag)
     }

--- a/Projects/Modules/DesignSystem/Sources/Component/Alert/PiCKApplyTimePickerAlert.swift
+++ b/Projects/Modules/DesignSystem/Sources/Component/Alert/PiCKApplyTimePickerAlert.swift
@@ -13,7 +13,7 @@ public class PiCKApplyTimePickerAlert: UIViewController {
 
     private var timePickerType: PickerType = .classroom
 
-    public var clickApplyButton: (() -> Void)?
+    public var applyButtonDidTap: (() -> Void)?
     public var selectedPeriod: ((Int, Int) -> Void)?
     public var selectedTime: ((String, String) -> Void)?
 
@@ -58,7 +58,7 @@ public class PiCKApplyTimePickerAlert: UIViewController {
                         self?.periodPickerView.startPeriodValue ?? 0,
                         self?.periodPickerView.endPeriodValue ?? 0
                     )
-                    self?.clickApplyButton!()
+                    self?.applyButtonDidTap!()
 
                 case .outingStart, .outingEnd, .earlyLeave:
                     let hour = self?.timePickerView.outingHourValue ?? 8

--- a/Projects/Modules/DesignSystem/Sources/Component/Button/PiCKImageButton.swift
+++ b/Projects/Modules/DesignSystem/Sources/Component/Button/PiCKImageButton.swift
@@ -9,7 +9,7 @@ import RxCocoa
 import Core
 
 public class PiCKImageButton: BaseButton {
-    public var buttonTap: ControlEvent<Void> {
+    public var buttonDidTap: ControlEvent<Void> {
         return self.rx.tap
     }
 

--- a/Projects/Modules/DesignSystem/Sources/Component/Calendar/PiCKCalendarAlert.swift
+++ b/Projects/Modules/DesignSystem/Sources/Component/Calendar/PiCKCalendarAlert.swift
@@ -11,7 +11,7 @@ import Core
 public class PiCKCalendarAlert: UIViewController {
     private let disposeBag = DisposeBag()
 
-    private var clickDate: (Date) -> Void
+    private var dateOnTap: (Date) -> Void
 
     private var calendarType: CalendarType
 
@@ -20,9 +20,9 @@ public class PiCKCalendarAlert: UIViewController {
     }
     private lazy var calendarView = PiCKCalendarView(
         calnedarType: calendarType,
-        clickDate: { date in
+        dateOnTap: { date in
             self.dismiss(animated: true) {
-                self.clickDate(date)
+                self.dateOnTap(date)
             }
         }
     )
@@ -36,10 +36,10 @@ public class PiCKCalendarAlert: UIViewController {
 
     public init(
         calendarType: CalendarType,
-        clickDate: @escaping (Date) -> Void
+        dateOnTap: @escaping (Date) -> Void
     ) {
         self.calendarType = calendarType
-        self.clickDate = clickDate
+        self.dateOnTap = dateOnTap
         super.init(nibName: nil, bundle: nil)
     }
     required init?(coder: NSCoder) {
@@ -62,7 +62,7 @@ public class PiCKCalendarAlert: UIViewController {
     }
 
     private func bind() {
-        self.toggleButton.buttonTap
+        self.toggleButton.buttonDidTap
             .bind { [weak self] in
                 self?.dismiss(animated: true)
             }.disposed(by: disposeBag)

--- a/Projects/Modules/DesignSystem/Sources/Component/Calendar/PiCKCalendarView.swift
+++ b/Projects/Modules/DesignSystem/Sources/Component/Calendar/PiCKCalendarView.swift
@@ -13,13 +13,13 @@ import Core
 public class PiCKCalendarView: BaseView, FSCalendarDelegate, FSCalendarDataSource {
     private var calendarType: CalendarType = .schoolMealWeek
 
-    private var clickDate: (Date) -> Void
+    private var dateOnTap: (Date) -> Void
 
-    public var clickTopToggleButton: ControlEvent<Void> {
-        return topToggleButton.buttonTap
+    public var topToggleButtonDidTap: ControlEvent<Void> {
+        return topToggleButton.buttonDidTap
     }
-    public var clickBottomToggleButton: ControlEvent<Void> {
-        return bottomToggleButton.buttonTap
+    public var bottomToggleButtonDidTap: ControlEvent<Void> {
+        return bottomToggleButton.buttonDidTap
     }
 
     private var dateSelectRelay = PublishRelay<Void>()
@@ -88,9 +88,9 @@ public class PiCKCalendarView: BaseView, FSCalendarDelegate, FSCalendarDataSourc
 
     public init(
         calnedarType: CalendarType,
-        clickDate: @escaping (Date) -> Void
+        dateOnTap: @escaping (Date) -> Void
     ) {
-        self.clickDate = clickDate
+        self.dateOnTap = dateOnTap
         self.calendarType = calnedarType
         super.init(frame: .zero)
 
@@ -195,7 +195,7 @@ extension PiCKCalendarView {
         _ calendar: FSCalendar,
         didSelect date: Date, at monthPosition: FSCalendarMonthPosition
     ) {
-        self.clickDate(date)
+        self.dateOnTap(date)
     }
 
 }

--- a/Projects/Modules/DesignSystem/Sources/Component/Navigation/PiCKMainNavigationBar.swift
+++ b/Projects/Modules/DesignSystem/Sources/Component/Navigation/PiCKMainNavigationBar.swift
@@ -13,10 +13,10 @@ public class PiCKMainNavigationBar: BaseView {
     private let userDefaultStorage = UserDefaultStorage.shared
 
     public var displayModeButtonTap: ControlEvent<Void> {
-        return displayModeButton.buttonTap
+        return displayModeButton.buttonDidTap
     }
     public var alertButtonTap: ControlEvent<Void> {
-        return alertButton.buttonTap
+        return alertButton.buttonDidTap
     }
 
     private let pickLogoImageView = UIImageView(image: .PiCKLogo).then {
@@ -47,7 +47,7 @@ public class PiCKMainNavigationBar: BaseView {
         self.backgroundColor = .clear
     }
     public override func bind() {
-        displayModeButton.buttonTap
+        displayModeButton.buttonDidTap
             .map {
                 let data = self.userDefaultStorage.get(forKey: .displayMode) as? Int
                 return data

--- a/Projects/Modules/DesignSystem/Sources/Component/View/PiCKTabView.swift
+++ b/Projects/Modules/DesignSystem/Sources/Component/View/PiCKTabView.swift
@@ -10,7 +10,7 @@ import RxGesture
 import Core
 
 public class PiCKTabView: BaseView {
-    public var clickActionButton: ControlEvent<Void> {
+    public var actionButtonDidTap: ControlEvent<Void> {
         return actionButton.buttonTap
     }
 

--- a/Projects/Presentation/Sources/Scene/AllTab/AllTabViewController.swift
+++ b/Projects/Presentation/Sources/Scene/AllTab/AllTabViewController.swift
@@ -45,13 +45,13 @@ public class AllTabViewController: BaseViewController<AllTabViewModel> {
     public override func bind() {
         let input = AllTabViewModel.Input(
             viewWillAppear: viewWillAppearRelay.asObservable(),
-            clickSelfStudyTab: helpSectionView.getSelectedItem(type: .selfStudy).asObservable(),
-            clickNoticeTab: helpSectionView.getSelectedItem(type: .notice).asObservable(),
-            clickBugReportTab: helpSectionView.getSelectedItem(type: .bugReport).asObservable(),
-            clickCutomTab: settingSectionView.getSelectedItem(type: .custom),
-            clickNotificationSettingTab: settingSectionView.getSelectedItem(type: .notification),
-            clickMyPageTab: accountSectionView.getSelectedItem(type: .myPage),
-            clickLogOutTab: logoutRelay.asObservable()
+            selfStudyTabDidTap: helpSectionView.getSelectedItem(type: .selfStudy).asObservable(),
+            noticeTabDidTap: helpSectionView.getSelectedItem(type: .notice).asObservable(),
+            bugReportTabDidTap: helpSectionView.getSelectedItem(type: .bugReport).asObservable(),
+            customTabDidTap: settingSectionView.getSelectedItem(type: .custom),
+            notificationSettingTabDidTap: settingSectionView.getSelectedItem(type: .notification),
+            myPageTabDidTap: accountSectionView.getSelectedItem(type: .myPage),
+            logOutButtonDidTap: logoutRelay.asObservable()
         )
 
         let output = viewModel.transform(input: input)

--- a/Projects/Presentation/Sources/Scene/AllTab/AllTabViewModel.swift
+++ b/Projects/Presentation/Sources/Scene/AllTab/AllTabViewModel.swift
@@ -24,13 +24,13 @@ public class AllTabViewModel: BaseViewModel, Stepper {
 
     public struct Input {
         let viewWillAppear: Observable<Void>
-        let clickSelfStudyTab: Observable<IndexPath>
-        let clickNoticeTab: Observable<IndexPath>
-        let clickBugReportTab: Observable<IndexPath>
-        let clickCutomTab: Observable<IndexPath>
-        let clickNotificationSettingTab: Observable<IndexPath>
-        let clickMyPageTab: Observable<IndexPath>
-        let clickLogOutTab: Observable<Void>
+        let selfStudyTabDidTap: Observable<IndexPath>
+        let noticeTabDidTap: Observable<IndexPath>
+        let bugReportTabDidTap: Observable<IndexPath>
+        let customTabDidTap: Observable<IndexPath>
+        let notificationSettingTabDidTap: Observable<IndexPath>
+        let myPageTabDidTap: Observable<IndexPath>
+        let logOutButtonDidTap: Observable<Void>
     }
     public struct Output {
         let profileData: Signal<SimpleProfileEntity>
@@ -50,37 +50,37 @@ public class AllTabViewModel: BaseViewModel, Stepper {
             .bind(to: profileData)
             .disposed(by: disposeBag)
 
-        input.clickSelfStudyTab
+        input.selfStudyTabDidTap
             .map { _ in PiCKStep.selfStudyIsRequired }
             .bind(to: steps)
             .disposed(by: disposeBag)
 
-        input.clickNoticeTab
+        input.noticeTabDidTap
             .map { _ in PiCKStep.noticeIsRequired }
             .bind(to: steps)
             .disposed(by: disposeBag)
 
-        input.clickBugReportTab
+        input.bugReportTabDidTap
             .map { _ in PiCKStep.bugReportIsRequired }
             .bind(to: steps)
             .disposed(by: disposeBag)
 
-        input.clickCutomTab
+        input.customTabDidTap
             .map { _ in PiCKStep.customIsRequired }
             .bind(to: steps)
             .disposed(by: disposeBag)
 
-        input.clickNotificationSettingTab
+        input.notificationSettingTabDidTap
             .map { _ in PiCKStep.notificationSettingIsRequired }
             .bind(to: steps)
             .disposed(by: disposeBag)
 
-        input.clickMyPageTab
+        input.myPageTabDidTap
             .map { _ in PiCKStep.myPageIsRequired }
             .bind(to: steps)
             .disposed(by: disposeBag)
 
-        input.clickLogOutTab
+        input.logOutButtonDidTap
             .do(onNext: { _ in
                 self.logoutUseCase.execute()
             })

--- a/Projects/Presentation/Sources/Scene/AllTab/Bug/BugReportViewController.swift
+++ b/Projects/Presentation/Sources/Scene/AllTab/Bug/BugReportViewController.swift
@@ -66,7 +66,7 @@ public class BugReportViewController: BaseViewController<BugReportViewModel> {
             bugTitle: bugTitleView.titleText.asObservable(),
             bugContent: bugExplainView.contentText.asObservable(),
             bugImages: bugDataArray.asObservable(),
-            clickBugReport: reportButton.buttonTap.asObservable()
+            bugReportButtonDidTap: reportButton.buttonTap.asObservable()
         )
 
         let output = viewModel.transform(input: input)

--- a/Projects/Presentation/Sources/Scene/AllTab/Bug/BugReportViewModel.swift
+++ b/Projects/Presentation/Sources/Scene/AllTab/Bug/BugReportViewModel.swift
@@ -26,7 +26,7 @@ public class BugReportViewModel: BaseViewModel, Stepper {
         let bugTitle: Observable<String?>
         let bugContent: Observable<String?>
         let bugImages: Observable<[Data]>
-        let clickBugReport: Observable<Void>
+        let bugReportButtonDidTap: Observable<Void>
     }
     public struct Output {
         let isReportButtonEnable: Signal<Bool>
@@ -43,7 +43,7 @@ public class BugReportViewModel: BaseViewModel, Stepper {
             !title!.isEmpty && !content!.isEmpty
         }
 
-        input.clickBugReport
+        input.bugReportButtonDidTap
             .withLatestFrom(info)
             .flatMap { title, content, images in
                 self.bugImageUploadUseCase.execute(images: images)

--- a/Projects/Presentation/Sources/Scene/AllTab/Component/Notification/NotificationSwitchView.swift
+++ b/Projects/Presentation/Sources/Scene/AllTab/Component/Notification/NotificationSwitchView.swift
@@ -14,7 +14,7 @@ public class NotificationSwitchView: BaseView {
     public var switchIsOn: Bool {
         return switchButton.isOn
     }
-    public var clickSwitchButton: ControlProperty<Bool> {
+    public var switchButtonDidTap: ControlProperty<Bool> {
         return switchButton.rx.isOn
     }
 

--- a/Projects/Presentation/Sources/Scene/AllTab/Custom/CustomSettingViewController.swift
+++ b/Projects/Presentation/Sources/Scene/AllTab/Custom/CustomSettingViewController.swift
@@ -43,8 +43,8 @@ public class CustomSettingViewController: BaseViewController<CustomSettingViewMo
     public override func bind() {
         let input = CustomSettingViewModel.Input(
             viewWillAppear: viewWillAppearRelay.asObservable(),
-            clickHomeSetting: homeSettingTabView.clickActionButton.asObservable(),
-            clickPickerSetting: pickerSettingTabView.clickActionButton.asObservable()
+            homeSettingButtonDidTap: homeSettingTabView.actionButtonDidTap.asObservable(),
+            pickerSettingButtonDidTap: pickerSettingTabView.actionButtonDidTap.asObservable()
         )
         let output = viewModel.transform(input: input)
 

--- a/Projects/Presentation/Sources/Scene/AllTab/Custom/CustomSettingViewModel.swift
+++ b/Projects/Presentation/Sources/Scene/AllTab/Custom/CustomSettingViewModel.swift
@@ -49,8 +49,8 @@ public class CustomSettingViewModel: BaseViewModel, Stepper {
 
     public struct Input {
         let viewWillAppear: Observable<Void>
-        let clickHomeSetting: Observable<Void>
-        let clickPickerSetting: Observable<Void>
+        let homeSettingButtonDidTap: Observable<Void>
+        let pickerSettingButtonDidTap: Observable<Void>
     }
     public struct Output {
         let homeSettingTabViewText: Driver<(String, String)>
@@ -67,7 +67,7 @@ public class CustomSettingViewModel: BaseViewModel, Stepper {
                 _ = self.pickerTimeType
             }).disposed(by: disposeBag)
 
-        input.clickHomeSetting
+        input.homeSettingButtonDidTap
             .subscribe(onNext: {
                 self.steps.accept(
                     PiCKStep.applyAlertIsRequired(
@@ -88,7 +88,7 @@ public class CustomSettingViewModel: BaseViewModel, Stepper {
                 )
             }).disposed(by: disposeBag)
 
-        input.clickPickerSetting
+        input.pickerSettingButtonDidTap
             .subscribe(onNext: {
                 self.steps.accept(
                     PiCKStep.applyAlertIsRequired(

--- a/Projects/Presentation/Sources/Scene/AllTab/Notification/NotificationSettingViewController.swift
+++ b/Projects/Presentation/Sources/Scene/AllTab/Notification/NotificationSettingViewController.swift
@@ -55,11 +55,11 @@ public class NotificationSettingViewController: BaseViewController<NotificationS
     public override func bind() {
         let input = NotificationSettingViewModel.Input(
             viewWillAppear: viewWillAppearRelay.asObservable(),
-            allStatus: allNotificationSwitchView.clickSwitchButton.asObservable(),
-            outingStatus: outingStatusSwitchView.clickSwitchButton.asObservable(),
-            classroomStatus: classroomStatusSwitchView.clickSwitchButton.asObservable(),
-            newNoticeStatus: noticeSwitchView.clickSwitchButton.asObservable(),
-            weekendMealStatus: weekendMealSwitchView.clickSwitchButton.asObservable()
+            allStatus: allNotificationSwitchView.switchButtonDidTap.asObservable(),
+            outingStatus: outingStatusSwitchView.switchButtonDidTap.asObservable(),
+            classroomStatus: classroomStatusSwitchView.switchButtonDidTap.asObservable(),
+            newNoticeStatus: noticeSwitchView.switchButtonDidTap.asObservable(),
+            weekendMealStatus: weekendMealSwitchView.switchButtonDidTap.asObservable()
         )
         let output = viewModel.transform(input: input)
 
@@ -99,7 +99,7 @@ public class NotificationSettingViewController: BaseViewController<NotificationS
             }.disposed(by: disposeBag)
     }
     public override func bindAction() {
-        allNotificationSwitchView.clickSwitchButton
+        allNotificationSwitchView.switchButtonDidTap
             .asObservable()
             .withUnretained(self)
             .bind { owner, isOn in
@@ -108,28 +108,28 @@ public class NotificationSettingViewController: BaseViewController<NotificationS
                 }
             }.disposed(by: disposeBag)
 
-        outingStatusSwitchView.clickSwitchButton
+        outingStatusSwitchView.switchButtonDidTap
             .asObservable()
             .withUnretained(self)
             .bind { owner, _ in
                 owner.toggleButton()
             }.disposed(by: disposeBag)
 
-        classroomStatusSwitchView.clickSwitchButton
+        classroomStatusSwitchView.switchButtonDidTap
             .asObservable()
             .withUnretained(self)
             .bind { owner, _ in
                 owner.toggleButton()
             }.disposed(by: disposeBag)
 
-        noticeSwitchView.clickSwitchButton
+        noticeSwitchView.switchButtonDidTap
             .asObservable()
             .withUnretained(self)
             .bind { owner, _ in
                 owner.toggleButton()
             }.disposed(by: disposeBag)
 
-        weekendMealSwitchView.clickSwitchButton
+        weekendMealSwitchView.switchButtonDidTap
             .asObservable()
             .withUnretained(self)
             .bind { owner, _ in

--- a/Projects/Presentation/Sources/Scene/AllTab/SelfStudy/SelfStudyViewController.swift
+++ b/Projects/Presentation/Sources/Scene/AllTab/SelfStudy/SelfStudyViewController.swift
@@ -42,7 +42,7 @@ public class SelfStudyViewController: BaseViewController<SelfStudyViewModel> {
     )
     private lazy var calendarView = PiCKCalendarView(
         calnedarType: .selfStudyWeek,
-        clickDate: { date in
+        dateOnTap: { date in
             self.loadSelfStudyRelay.accept(date.toString(type: .fullDate))
             if date.toString(type: .fullDate) == self.todayDate.toString(type: .fullDate) {
                 self.titleLabel.text = "\(date.toString(type: .monthAndDayKor)),\n오늘의 자습 감독 선생님입니다"
@@ -80,11 +80,11 @@ public class SelfStudyViewController: BaseViewController<SelfStudyViewModel> {
                 self?.setupSelftStudyLabel(data: data)
             }).disposed(by: disposeBag)
 
-        self.calendarView.clickTopToggleButton
+        self.calendarView.topToggleButtonDidTap
             .subscribe(onNext: { [weak self] in
                 let alert = PiCKCalendarAlert(
                     calendarType: .selfStudyMonth,
-                    clickDate: { date in
+                    dateOnTap: { date in
                         self?.calendarView.setupDate(date: date)
                         self?.loadSelfStudyRelay.accept(date.toString(type: .fullDate))
 

--- a/Projects/Presentation/Sources/Scene/Apply/ApplyViewController.swift
+++ b/Projects/Presentation/Sources/Scene/Apply/ApplyViewController.swift
@@ -24,10 +24,10 @@ public class ApplyViewController: BaseViewController<ApplyViewModel> {
     }
     public override func bind() {
         let input = ApplyViewModel.Input(
-            clickWeekendMealButton: applyTabView.clickWeekendMealTab.asObservable(),
-            clickClassroomMoveButton: applyTabView.clickClassroomMoveTab.asObservable(),
-            clickOutingButton: applyTabView.clickOutingTab.asObservable(),
-            clickEarlyLeaveButton: applyTabView.clickEarlyLeaveTab.asObservable()
+            weekendMealApplyButtonDidTap: applyTabView.weekendMealTabDidTap.asObservable(),
+            classroomMoveApplyButtonDidTap: applyTabView.classroomMoveTabDidTap.asObservable(),
+            outingApplyButtonDidTap: applyTabView.outingTabDidTap.asObservable(),
+            earlyLeaveApplyButtonDidTap: applyTabView.earlyLeaveTabDidTap.asObservable()
         )
         _ = viewModel.transform(input: input)
     }

--- a/Projects/Presentation/Sources/Scene/Apply/ApplyViewModel.swift
+++ b/Projects/Presentation/Sources/Scene/Apply/ApplyViewModel.swift
@@ -14,30 +14,30 @@ public class ApplyViewModel: BaseViewModel, Stepper {
     public init() {}
 
     public struct Input {
-        let clickWeekendMealButton: Observable<Void>
-        let clickClassroomMoveButton: Observable<Void>
-        let clickOutingButton: Observable<Void>
-        let clickEarlyLeaveButton: Observable<Void>
+        let weekendMealApplyButtonDidTap: Observable<Void>
+        let classroomMoveApplyButtonDidTap: Observable<Void>
+        let outingApplyButtonDidTap: Observable<Void>
+        let earlyLeaveApplyButtonDidTap: Observable<Void>
     }
     public struct Output {}
 
     public func transform(input: Input) -> Output {
-        input.clickWeekendMealButton
+        input.weekendMealApplyButtonDidTap
             .map { PiCKStep.weekendMealApplyIsRequired }
             .bind(to: steps)
             .disposed(by: disposeBag)
 
-        input.clickClassroomMoveButton
+        input.classroomMoveApplyButtonDidTap
             .map { PiCKStep.classroomMoveApplyIsRequired }
             .bind(to: steps)
             .disposed(by: disposeBag)
 
-        input.clickOutingButton
+        input.outingApplyButtonDidTap
             .map { PiCKStep.outingApplyIsRequired }
             .bind(to: steps)
             .disposed(by: disposeBag)
 
-        input.clickEarlyLeaveButton
+        input.earlyLeaveApplyButtonDidTap
             .map { PiCKStep.earlyLeaveApplyIsRequired }
             .bind(to: steps)
             .disposed(by: disposeBag)

--- a/Projects/Presentation/Sources/Scene/Apply/Classroom/ClassroomMoveApplyViewController.swift
+++ b/Projects/Presentation/Sources/Scene/Apply/Classroom/ClassroomMoveApplyViewController.swift
@@ -64,7 +64,7 @@ public class ClassroomMoveApplyViewController: BaseViewController<ClassroomMoveA
             classroomText: classroomText.asObservable(),
             startPeriod: startPeriod.asObservable(),
             endPeriod: endPeriod.asObservable(),
-            clickClassroomMoveApply: classroomMoveApplyRelay.asObservable()
+            classroomMoveApplyButtonDidTap: classroomMoveApplyRelay.asObservable()
         )
 
         let output = viewModel.transform(input: input)
@@ -122,7 +122,7 @@ public class ClassroomMoveApplyViewController: BaseViewController<ClassroomMoveA
                     self?.startPeriod.accept(startPeriod)
                     self?.endPeriod.accept(endPeriod)
                 }
-                alert.clickApplyButton = { [weak self] in
+                alert.applyButtonDidTap = { [weak self] in
                     self?.classroomMoveApplyRelay.accept(())
                 }
 

--- a/Projects/Presentation/Sources/Scene/Apply/Classroom/ClassroomMoveApplyViewModel.swift
+++ b/Projects/Presentation/Sources/Scene/Apply/Classroom/ClassroomMoveApplyViewModel.swift
@@ -22,7 +22,7 @@ public class ClassroomMoveApplyViewModel: BaseViewModel, Stepper {
         let classroomText: Observable<String>
         let startPeriod: Observable<Int>
         let endPeriod: Observable<Int>
-        let clickClassroomMoveApply: Observable<Void>
+        let classroomMoveApplyButtonDidTap: Observable<Void>
     }
     public struct Output {
         let isApplyButtonEnable: Signal<Bool>
@@ -45,7 +45,7 @@ public class ClassroomMoveApplyViewModel: BaseViewModel, Stepper {
             !classRoom.isEmpty
         }
 
-        input.clickClassroomMoveApply
+        input.classroomMoveApplyButtonDidTap
             .withLatestFrom(info)
             .flatMap { floor, classroom, startPeriod, endPeriod in
                 self.classroomMoveApplyUseCase.execute(req: .init(

--- a/Projects/Presentation/Sources/Scene/Apply/Component/Apply/PiCKApplyStackView.swift
+++ b/Projects/Presentation/Sources/Scene/Apply/Component/Apply/PiCKApplyStackView.swift
@@ -11,17 +11,17 @@ import Core
 import DesignSystem
 
 public class PiCKApplyStackView: BaseView {
-    public var clickWeekendMealTab: ControlEvent<Void> {
-        return weekendMealApplyTab.clickActionButton
+    public var weekendMealTabDidTap: ControlEvent<Void> {
+        return weekendMealApplyTab.actionButtonDidTap
     }
-    public var clickClassroomMoveTab: ControlEvent<Void> {
-        return classroomMoveApplyTab.clickActionButton
+    public var classroomMoveTabDidTap: ControlEvent<Void> {
+        return classroomMoveApplyTab.actionButtonDidTap
     }
-    public var clickOutingTab: ControlEvent<Void> {
-        return outingApplyTab.clickActionButton
+    public var outingTabDidTap: ControlEvent<Void> {
+        return outingApplyTab.actionButtonDidTap
     }
-    public var clickEarlyLeaveTab: ControlEvent<Void> {
-        return earlyLeaveApplyTab.clickActionButton
+    public var earlyLeaveTabDidTap: ControlEvent<Void> {
+        return earlyLeaveApplyTab.actionButtonDidTap
     }
 
     private let weekendMealApplyTab = PiCKTabView(

--- a/Projects/Presentation/Sources/Scene/Apply/Component/WeekendMeal/WeekendMealApplyView.swift
+++ b/Projects/Presentation/Sources/Scene/Apply/Component/WeekendMeal/WeekendMealApplyView.swift
@@ -10,7 +10,7 @@ import Core
 import DesignSystem
 
 public class WeekendMealApplyView: BaseView {
-    public var clickWeekendMealStatus: (WeekendMealType) -> Void
+    public var weekendMealStatusButtonDidTap: (WeekendMealType) -> Void
 
     public var applyState = BehaviorRelay<Bool>(value: false)
 
@@ -44,13 +44,13 @@ public class WeekendMealApplyView: BaseView {
 
         self.buttonStackView.isHidden = !isApplicable
         self.applyState.accept(status)
-        self.clickWeekendMealStatus(status ? .ok : .no)
+        self.weekendMealStatusButtonDidTap(status ? .ok : .no)
     }
 
     public init(
-        clickWeekendMealStatus: @escaping (WeekendMealType) -> Void
+        weekendMealStatusButtonDidTap: @escaping (WeekendMealType) -> Void
     ) {
-        self.clickWeekendMealStatus = clickWeekendMealStatus
+        self.weekendMealStatusButtonDidTap = weekendMealStatusButtonDidTap
         super.init(frame: .zero)
     }
     required init?(coder: NSCoder) {
@@ -73,12 +73,12 @@ public class WeekendMealApplyView: BaseView {
 
         applyButton.buttonTap
             .bind { [self] in
-                clickRadioButton(button: applyButton)
+                radioButtonDidTap(button: applyButton)
             }.disposed(by: disposeBag)
 
         notApplyButton.buttonTap
             .bind { [self] in
-                clickRadioButton(button: notApplyButton)
+                radioButtonDidTap(button: notApplyButton)
             }.disposed(by: disposeBag)
     }
     public override func layout() {
@@ -97,7 +97,7 @@ public class WeekendMealApplyView: BaseView {
         }
     }
 
-    private func clickRadioButton(button: WeekendMealApplyButton) {
+    private func radioButtonDidTap(button: WeekendMealApplyButton) {
         if button == applyButton {
             applyState.accept(true)
         } else if button == notApplyButton {
@@ -107,7 +107,7 @@ public class WeekendMealApplyView: BaseView {
         applyButton.isSelected = applyState.value
         notApplyButton.isSelected = !applyState.value
 
-        clickWeekendMealStatus(applyState.value == true ? .ok : .no)
+        weekendMealStatusButtonDidTap(applyState.value == true ? .ok : .no)
     }
 
 }

--- a/Projects/Presentation/Sources/Scene/Apply/EarlyLeave/EarlyLeaveApplyViewController.swift
+++ b/Projects/Presentation/Sources/Scene/Apply/EarlyLeave/EarlyLeaveApplyViewController.swift
@@ -40,9 +40,9 @@ public class EarlyLeaveApplyViewController: BaseViewController<EarlyLeaveApplyVi
     public override func bind() {
         let input = EarlyLeaveApplyViewModel.Input(
             startTime: startTime.asObservable(),
-            clickStartTime: startTimeSelectButton.buttonTap.asObservable(),
+            selectStartTimeButtonDidTap: startTimeSelectButton.buttonTap.asObservable(),
             reasonText: outingReasonTextView.textViewText.asObservable(),
-            clickEarlyLeaveApply: applyButton.buttonTap.asObservable()
+            earlyLeaveApplyButtonDidTap: applyButton.buttonTap.asObservable()
         )
         let output =  viewModel.transform(input: input)
 

--- a/Projects/Presentation/Sources/Scene/Apply/EarlyLeave/EarlyLeaveApplyViewModel.swift
+++ b/Projects/Presentation/Sources/Scene/Apply/EarlyLeave/EarlyLeaveApplyViewModel.swift
@@ -19,9 +19,9 @@ public class EarlyLeaveApplyViewModel: BaseViewModel, Stepper {
 
     public struct Input {
         let startTime: Observable<String>
-        let clickStartTime: Observable<Void>
+        let selectStartTimeButtonDidTap: Observable<Void>
         let reasonText: Observable<String?>
-        let clickEarlyLeaveApply: Observable<Void>
+        let earlyLeaveApplyButtonDidTap: Observable<Void>
     }
     public struct Output {
         let isApplyButtonEnable: Signal<Bool>
@@ -36,7 +36,7 @@ public class EarlyLeaveApplyViewModel: BaseViewModel, Stepper {
         let isApplyButtonEnable = info.map { reason, startTime -> Bool in !reason!.isEmpty && !startTime.isEmpty
         }
 
-        input.clickEarlyLeaveApply
+        input.earlyLeaveApplyButtonDidTap
             .withLatestFrom(info)
             .flatMap { reason, startTime in
                 self.earlyLeaveApplyUseCase.execute(req: .init(

--- a/Projects/Presentation/Sources/Scene/Apply/Outing/OutingApplyViewController.swift
+++ b/Projects/Presentation/Sources/Scene/Apply/Outing/OutingApplyViewController.swift
@@ -77,12 +77,12 @@ public class OutingApplyViewController: BaseViewController<OutingApplyViewModel>
     public override func bind() {
         let input = OutingApplyViewModel.Input(
             startTime: startTimeRelay.asObservable(),
-            clickStartTimeButton: startTimeSelectButton.buttonTap.asObservable(),
+            selectStartTimeButtonDidTap: startTimeSelectButton.buttonTap.asObservable(),
             endTime: endTimeRelay.asObservable(),
-            clickEndTimeButton: endTimeSelectButton.buttonTap.asObservable(),
+            selectEndTimeButtonDidTap: endTimeSelectButton.buttonTap.asObservable(),
             reasonText: outingReasonTextView.textViewText.asObservable(),
             applicationType: applicationType.asObservable(),
-            clickOutingApply: applyButton.buttonTap.asObservable()
+            outingApplyButtonDidTap: applyButton.buttonTap.asObservable()
         )
 
         let output =  viewModel.transform(input: input)
@@ -139,7 +139,7 @@ public class OutingApplyViewController: BaseViewController<OutingApplyViewModel>
 
                     self?.applicationType.accept(.period)
                 }
-                alert.clickApplyButton = {
+                alert.applyButtonDidTap = {
                     print("success")
                 }
 

--- a/Projects/Presentation/Sources/Scene/Apply/Outing/OutingApplyViewModel.swift
+++ b/Projects/Presentation/Sources/Scene/Apply/Outing/OutingApplyViewModel.swift
@@ -19,12 +19,12 @@ public class OutingApplyViewModel: BaseViewModel, Stepper {
 
     public struct Input {
         let startTime: Observable<String>
-        let clickStartTimeButton: Observable<Void>
+        let selectStartTimeButtonDidTap: Observable<Void>
         let endTime: Observable<String>
-        let clickEndTimeButton: Observable<Void>
+        let selectEndTimeButtonDidTap: Observable<Void>
         let reasonText: Observable<String?>
         let applicationType: Observable<PickerTimeSelectType>
-        let clickOutingApply: Observable<Void>
+        let outingApplyButtonDidTap: Observable<Void>
     }
     public struct Output {
         let isApplyButtonEnable: Signal<Bool>
@@ -49,7 +49,7 @@ public class OutingApplyViewModel: BaseViewModel, Stepper {
             return startTime <= endTime
         }
 
-        input.clickOutingApply
+        input.outingApplyButtonDidTap
             .withLatestFrom(info)
             .flatMap { reason, startTime, endTime, applicationType in
                 self.outingApplyUseCase.execute(req: .init(

--- a/Projects/Presentation/Sources/Scene/Apply/WeekendMeal/WeekendMealApplyViewController.swift
+++ b/Projects/Presentation/Sources/Scene/Apply/WeekendMeal/WeekendMealApplyViewController.swift
@@ -22,7 +22,7 @@ public class WeekendMealApplyViewController: BaseViewController<WeekendMealApply
         textColor: .gray500,
         font: .pickFont(.caption2)
     )
-    private lazy var weekendMealApplyView = WeekendMealApplyView(clickWeekendMealStatus: { data in
+    private lazy var weekendMealApplyView = WeekendMealApplyView(weekendMealStatusButtonDidTap: { data in
         self.weekendMealStatusRelay.accept(data)
     })
     private let saveButton = PiCKButton(buttonText: "저장하기")
@@ -37,7 +37,7 @@ public class WeekendMealApplyViewController: BaseViewController<WeekendMealApply
         let input = WeekendMealApplyViewModel.Input(
             viewWillAppear: viewWillAppearRelay.asObservable(),
             applyStatus: weekendMealStatusRelay.asObservable(),
-            clickApplyButton: saveButton.buttonTap.asObservable()
+            weekendMealApplyButtonDidTap: saveButton.buttonTap.asObservable()
         )
         let output = viewModel.transform(input: input)
 

--- a/Projects/Presentation/Sources/Scene/Apply/WeekendMeal/WeekendMealApplyViewModel.swift
+++ b/Projects/Presentation/Sources/Scene/Apply/WeekendMeal/WeekendMealApplyViewModel.swift
@@ -28,7 +28,7 @@ public class WeekendMealApplyViewModel: BaseViewModel, Stepper {
     public struct Input {
         let viewWillAppear: Observable<Void>
         let applyStatus: Observable<WeekendMealType>
-        let clickApplyButton: Observable<Void>
+        let weekendMealApplyButtonDidTap: Observable<Void>
     }
     public struct Output {
         let weekendMealStatus: Signal<WeekendMealType>
@@ -64,7 +64,7 @@ public class WeekendMealApplyViewModel: BaseViewModel, Stepper {
             .bind(to: weekendMealApplicationPeriod)
             .disposed(by: disposeBag)
 
-        input.clickApplyButton
+        input.weekendMealApplyButtonDidTap
             .withLatestFrom(input.applyStatus)
             .flatMap { status in
                 let alertType = status == .ok ? DisappearAlertType.weekendMeal : .weekendMealCancel

--- a/Projects/Presentation/Sources/Scene/Home/Header/HomePassHeaderView.swift
+++ b/Projects/Presentation/Sources/Scene/Home/Header/HomePassHeaderView.swift
@@ -62,36 +62,29 @@ public class HomePassHeaderView: BaseView {
         classRoomText: String? = nil
     ) {
         if isWait == true {
-//            self.waitingContentLabel.text = "상태가 바뀌면 픽에서 알림을 드릴게요!"
-            switch type {
-            case .application:
-                self.waitingTitleLabel.text = "외출 수락 대기 중입니다"
-            case .earlyReturn:
-                self.waitingTitleLabel.text = "조기귀가 수락 대기 중입니다"
-            case .classroom:
-                self.waitingTitleLabel.text = "교실 이동 수락 대기 중입니다"
-            }
+            self.waitingTitleLabel.text = type.toExplainText
         } else {
+            let timeValue: String
+            let message: String
+
             switch type {
             case .application:
-                let timeValue = "\(startTime ?? "") - \(endTime ?? "")"
+                timeValue = "\(startTime ?? "") - \(endTime ?? "")"
+                message = "\(userName)님의 외출 시간은\n\(timeValue)입니다"
 
-                self.contentLabel.text = "\(userName)님의 외출 시간은\n\(timeValue) 입니다"
-                self.contentLabel.changePointColor(targetString: timeValue, color: .main500)
-
-                self.button.setTitle("외출증 보기", for: .normal)
             case .earlyReturn:
-                self.contentLabel.text = "\(userName)님의 귀가 시간은\n\(startTime ?? "") 입니다"
-                self.contentLabel.changePointColor(targetString: startTime ?? "", color: .main500)
-                self.button.setTitle("외출증 보기", for: .normal)
+                timeValue = startTime ?? ""
+                message = "\(userName)님의 귀가 시간은\n\(timeValue)입니다"
 
             case .classroom:
-                let timeValue = "\(startTime ?? "")교시 - \(endTime ?? "")교시"
-
-                self.contentLabel.text = "\(classRoomText ?? "정보 없음") 이동 시간은\n\(timeValue) 입니다"
-                self.contentLabel.changePointColor(targetString: timeValue, color: .main500)
-                self.button.setTitle("돌아가기", for: .normal)
+                timeValue = "\(startTime ?? "")교시 - \(endTime ?? "")교시"
+                let classroom = classRoomText ?? "정보 없음"
+                message = "\(classroom) 이동 시간은\n\(timeValue)입니다"
             }
+
+            self.contentLabel.text = message
+            self.contentLabel.changePointColor(targetString: timeValue, color: .main500)
+            self.button.setTitle(type.toPassText, for: .normal)
         }
         self.setupType(isWait: isWait)
     }
@@ -120,7 +113,6 @@ public class HomePassHeaderView: BaseView {
             $0.width.equalTo(120)
             $0.height.equalTo(40)
         }
-
         waitingStackView.snp.makeConstraints {
             $0.center.equalToSuperview()
         }

--- a/Projects/Presentation/Sources/Scene/Home/HomeViewController.swift
+++ b/Projects/Presentation/Sources/Scene/Home/HomeViewController.swift
@@ -14,7 +14,7 @@ public class HomeViewController: BaseViewController<HomeViewModel> {
     private var homeViewType: HomeViewType = .timeTable
     private var outingPassType = PublishRelay<OutingType>()
 
-    private var clickNoticeRelay = PublishRelay<UUID>()
+    private var noticeButtonDidTapRelay = PublishRelay<UUID>()
 
     private let todayDate = Date()
 
@@ -129,11 +129,11 @@ public class HomeViewController: BaseViewController<HomeViewModel> {
         let input = HomeViewModel.Input(
             todayDate: todayDate.toString(type: .fullDate),
             viewWillAppear: viewWillAppearRelay.asObservable(),
-            clickAlert: navigationBar.alertButtonTap.asObservable(),
-            clickOutingPass: passHeaderView.buttonTap.asObservable(),
+            alertButtonDidTap: navigationBar.alertButtonTap.asObservable(),
+            outingPassDidTap: passHeaderView.buttonTap.asObservable(),
             outingPassType: outingPassType.asObservable(),
-            clickViewMoreNotice: viewMoreButton.rx.tap.asObservable(),
-            clickNotice: clickNoticeRelay.asObservable()
+            viewMoreNoticeButtonDidTap: viewMoreButton.rx.tap.asObservable(),
+            noticeDidSelect: noticeButtonDidTapRelay.asObservable()
         )
         let output = viewModel.transform(input: input)
 
@@ -215,7 +215,7 @@ public class HomeViewController: BaseViewController<HomeViewModel> {
             .modelSelected(NoticeListEntityElement.self)
             .withUnretained(self)
             .bind { owner, data in
-                owner.clickNoticeRelay.accept(data.id)
+                owner.noticeButtonDidTapRelay.accept(data.id)
             }.disposed(by: disposeBag)
 
         output.outingPassData.asObservable()

--- a/Projects/Presentation/Sources/Scene/Home/HomeViewController.swift
+++ b/Projects/Presentation/Sources/Scene/Home/HomeViewController.swift
@@ -227,10 +227,10 @@ public class HomeViewController: BaseViewController<HomeViewModel> {
                 owner.present(pass, animated: true)
                 pass.setup(
                     name: data.userName,
-                    info: "\(data.grade ?? 0)학년 \(data.classNum ?? 0)반 \(data.num ?? 0)번",
-                    time: "\(data.start ?? "") ~ \(data.end ?? "")",
-                    reason: data.reason,
-                    teacher: "\(data.teacherName) 선생님"
+                    gcn: data.gcn ?? "",
+                    time: data.time ?? "",
+                    reason: data.reason ?? "",
+                    teacher: data.teacherName
                 )
             }.disposed(by: disposeBag)
 

--- a/Projects/Presentation/Sources/Scene/Home/HomeViewModel.swift
+++ b/Projects/Presentation/Sources/Scene/Home/HomeViewModel.swift
@@ -51,11 +51,11 @@ public class HomeViewModel: BaseViewModel, Stepper {
     public struct Input {
         let todayDate: String
         let viewWillAppear: Observable<Void>
-        let clickAlert: Observable<Void>
-        let clickOutingPass: Observable<Void>
+        let alertButtonDidTap: Observable<Void>
+        let outingPassDidTap: Observable<Void>
         let outingPassType: Observable<OutingType>
-        let clickViewMoreNotice: Observable<Void>
-        let clickNotice: Observable<UUID>
+        let viewMoreNoticeButtonDidTap: Observable<Void>
+        let noticeDidSelect: Observable<UUID>
     }
     public struct Output {
         let viewMode: Signal<HomeViewType>
@@ -194,7 +194,7 @@ public class HomeViewModel: BaseViewModel, Stepper {
             .bind(to: outingPassType)
             .disposed(by: disposeBag)
 
-        input.clickOutingPass
+        input.outingPassDidTap
             .flatMap {
                 switch self.outingPassType.value {
                 case .application:
@@ -211,17 +211,17 @@ public class HomeViewModel: BaseViewModel, Stepper {
             .bind(to: outingPassData)
             .disposed(by: disposeBag)
 
-        input.clickAlert
+        input.alertButtonDidTap
             .map { PiCKStep.alertIsRequired }
             .bind(to: steps)
             .disposed(by: disposeBag)
 
-        input.clickViewMoreNotice
+        input.viewMoreNoticeButtonDidTap
             .map { PiCKStep.noticeIsRequired }
             .bind(to: steps)
             .disposed(by: disposeBag)
 
-        input.clickNotice
+        input.noticeDidSelect
             .map { id in
                 PiCKStep.noticeDetailIsRequired(id: id)
             }

--- a/Projects/Presentation/Sources/Scene/Home/HomeViewModel.swift
+++ b/Projects/Presentation/Sources/Scene/Home/HomeViewModel.swift
@@ -117,8 +117,8 @@ public class HomeViewModel: BaseViewModel, Stepper {
                     }
             }
             .subscribe(onNext: { data in
-                let infoValue = "\(data.grade)학년 \(data.classNum)반 \(data.num)번 \(data.name)"
-
+                let infoValue = "\(data.gcn) \(data.name)"
+                
                 self.userDefaultStorage.set(to: infoValue, forKey: .userInfoData)
                 self.userDefaultStorage.set(to: data.name, forKey: .userNameData)
                 self.profileData.accept(data)

--- a/Projects/Presentation/Sources/Scene/Home/Pass/PassView.swift
+++ b/Projects/Presentation/Sources/Scene/Home/Pass/PassView.swift
@@ -22,18 +22,17 @@ public class PassView: UIViewController {
         textColor: .modeBlack,
         font: .pickFont(.subTitle1)
     )
-
     private let nameLabel = PiCKLabel(
         textColor: .modeBlack,
         font: .pickFont(.heading2)
     )
-    private let infoLabel = PiCKLabel(
+    private let gcnLabel = PiCKLabel(
         textColor: .gray700,
         font: .pickFont(.subTitle2)
     )
     private lazy var userInfoStackView = UIStackView(arrangedSubviews: [
         nameLabel,
-        infoLabel
+        gcnLabel
     ]).then {
         $0.axis = .vertical
         $0.spacing = 6
@@ -55,13 +54,13 @@ public class PassView: UIViewController {
 
     public func setup(
         name: String,
-        info: String,
+        gcn: String,
         time: String,
         reason: String,
         teacher: String
     ) {
         self.nameLabel.text = name
-        self.infoLabel.text = info
+        self.gcnLabel.text = gcn
         self.outingTimeView.setup(content: time)
         self.reasonView.setup(content: reason)
         self.aproveTeacherView.setup(content: teacher)

--- a/Projects/Presentation/Sources/Scene/Notice/List/NoticeListViewController.swift
+++ b/Projects/Presentation/Sources/Scene/Notice/List/NoticeListViewController.swift
@@ -11,7 +11,7 @@ import Domain
 import DesignSystem
 
 public class NoticeListViewController: BaseViewController<NoticeListViewModel> {
-    private let clickNoticeCellRelay = PublishRelay<UUID>()
+    private let noticeDidSelectRelay = PublishRelay<UUID>()
 
     private lazy var collectionViewFlowLayout = UICollectionViewFlowLayout().then {
         $0.scrollDirection = .vertical
@@ -36,7 +36,7 @@ public class NoticeListViewController: BaseViewController<NoticeListViewModel> {
     public override func bind() {
         let input = NoticeListViewModel.Input(
             viewWillAppear: viewWillAppearRelay.asObservable(),
-            clickNoticeCell: clickNoticeCellRelay.asObservable()
+            noticeDidSelect: noticeDidSelectRelay.asObservable()
         )
         let output = viewModel.transform(input: input)
 
@@ -52,7 +52,7 @@ public class NoticeListViewController: BaseViewController<NoticeListViewModel> {
             .modelSelected(NoticeListEntityElement.self)
             .withUnretained(self)
             .bind { owner, data in
-                owner.clickNoticeCellRelay.accept(data.id)
+                owner.noticeDidSelectRelay.accept(data.id)
             }.disposed(by: disposeBag)
     }
 

--- a/Projects/Presentation/Sources/Scene/Notice/List/NoticeListViewModel.swift
+++ b/Projects/Presentation/Sources/Scene/Notice/List/NoticeListViewModel.swift
@@ -20,7 +20,7 @@ public class NoticeListViewModel: BaseViewModel, Stepper {
 
     public struct Input {
         let viewWillAppear: Observable<Void>
-        let clickNoticeCell: Observable<UUID>
+        let noticeDidSelect: Observable<UUID>
     }
     public struct Output {
         let noticeListData: Driver<NoticeListEntity>
@@ -40,7 +40,7 @@ public class NoticeListViewModel: BaseViewModel, Stepper {
             .bind(to: noticeListData)
             .disposed(by: disposeBag)
 
-        input.clickNoticeCell
+        input.noticeDidSelect
             .map { id in
                 PiCKStep.noticeDetailIsRequired(id: id)
             }

--- a/Projects/Presentation/Sources/Scene/OnBoarding/OnBoardingViewController.swift
+++ b/Projects/Presentation/Sources/Scene/OnBoarding/OnBoardingViewController.swift
@@ -32,7 +32,7 @@ public class OnboardingViewController: BaseViewController<OnboardingViewModel> {
         let input = OnboardingViewModel.Input(
             viewWillAppear: viewWillAppearRelay.asObservable(),
             componentAppear: componentAppearRelay.asObservable(),
-            clickOnboardingButton: onboardingButton.buttonTap.asObservable()
+            onboardingButtonDidTap: onboardingButton.buttonTap.asObservable()
         )
         let output = viewModel.transform(input: input)
 

--- a/Projects/Presentation/Sources/Scene/OnBoarding/OnboardingViewModel.swift
+++ b/Projects/Presentation/Sources/Scene/OnBoarding/OnboardingViewModel.swift
@@ -29,7 +29,7 @@ public class OnboardingViewModel: BaseViewModel, Stepper {
     public struct Input {
         let viewWillAppear: Observable<Void>
         let componentAppear: Observable<Void>
-        let clickOnboardingButton: Observable<Void>
+        let onboardingButtonDidTap: Observable<Void>
     }
     public struct Output {
         let animate: Signal<Void>
@@ -80,7 +80,7 @@ public class OnboardingViewModel: BaseViewModel, Stepper {
             .bind(to: showComponent)
             .disposed(by: disposeBag)
 
-        input.clickOnboardingButton
+        input.onboardingButtonDidTap
             .map { PiCKStep.loginIsRequired }
             .bind(to: steps)
             .disposed(by: disposeBag)

--- a/Projects/Presentation/Sources/Scene/Schedule/AcademicSchedule/View/AcademicScheduleView.swift
+++ b/Projects/Presentation/Sources/Scene/Schedule/AcademicSchedule/View/AcademicScheduleView.swift
@@ -11,8 +11,8 @@ import Domain
 import DesignSystem
 
 public class AcademicScheduleView: BaseView {
-    public var clickYearAndMonth: (Date, Date) -> Void
-    public var clickDate: (Date) -> Void
+    public var yearAndMonthOnTap: (Date, Date) -> Void
+    public var dateOnTap: (Date) -> Void
 
     private lazy var monthAcademicScheduleData = BehaviorRelay<AcademicScheduleEntity>(value: [])
     private lazy var academicScheduleData = BehaviorRelay<AcademicScheduleEntity>(value: [])
@@ -20,10 +20,10 @@ public class AcademicScheduleView: BaseView {
     private let todayDate = Date()
 
     private lazy var calenderView = AcademicScheduleCalendar(
-        clickYearAndMonth: { year, month in
-            self.clickYearAndMonth(year, month)
-        }, clickDate: { date in
-            self.clickDate(date)
+        yearAndMonthOnTap: { year, month in
+            self.yearAndMonthOnTap(year, month)
+        }, dateOnTap: { date in
+            self.dateOnTap(date)
             if date.toString(type: .fullDate) == self.todayDate.toString(type: .fullDate) {
                 self.dateLabel.text = "오늘 \(date.toString(type: .monthAndDayKor))"
                 self.dateLabel.changePointColor(targetString: "오늘", color: .main500)
@@ -86,11 +86,11 @@ public class AcademicScheduleView: BaseView {
 
     public init(
         frame: CGRect,
-        clickYearAndMonth: @escaping (Date, Date) -> Void,
-        clickDate: @escaping (Date) -> Void
+        yearAndMonthOnTap: @escaping (Date, Date) -> Void,
+        dateOnTap: @escaping (Date) -> Void
     ) {
-        self.clickYearAndMonth = clickYearAndMonth
-        self.clickDate = clickDate
+        self.yearAndMonthOnTap = yearAndMonthOnTap
+        self.dateOnTap = dateOnTap
         super.init(frame: frame)
     }
     required init?(coder: NSCoder) {

--- a/Projects/Presentation/Sources/Scene/Schedule/Component/AcademicScheduleCalendar.swift
+++ b/Projects/Presentation/Sources/Scene/Schedule/Component/AcademicScheduleCalendar.swift
@@ -13,8 +13,8 @@ import Domain
 import DesignSystem
 
 public class AcademicScheduleCalendar: BaseView, FSCalendarDelegate, FSCalendarDataSource {
-    public var clickYearAndMonth: (Date, Date) -> Void
-    public var clickDate: (Date) -> Void
+    public var yearAndMonthOnTap: (Date, Date) -> Void
+    public var dateOnTap: (Date) -> Void
 
     private var dateSelectRelay = PublishRelay<Void>()
     private var monthAcademicScheduleData = BehaviorRelay<AcademicScheduleEntity>(value: [])
@@ -74,15 +74,15 @@ public class AcademicScheduleCalendar: BaseView, FSCalendarDelegate, FSCalendarD
     }
 
     public init(
-        clickYearAndMonth: @escaping (Date, Date) -> Void,
-        clickDate: @escaping (Date) -> Void
+        yearAndMonthOnTap: @escaping (Date, Date) -> Void,
+        dateOnTap: @escaping (Date) -> Void
     ) {
-        self.clickYearAndMonth = clickYearAndMonth
-        self.clickDate = clickDate
+        self.yearAndMonthOnTap = yearAndMonthOnTap
+        self.dateOnTap = dateOnTap
         super.init(frame: .zero)
 
         let todayDate = Date()
-        clickDate(todayDate)
+        dateOnTap(todayDate)
     }
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
@@ -126,7 +126,7 @@ public class AcademicScheduleCalendar: BaseView, FSCalendarDelegate, FSCalendarD
         let calendar = Calendar.current
         if let startOfMonth = calendar.date(from: calendar.dateComponents([.year, .month], from: date)),
            let endOfMonth = calendar.date(byAdding: DateComponents(month: 1, day: -1), to: startOfMonth) {
-            clickYearAndMonth(startOfMonth, endOfMonth)
+            yearAndMonthOnTap(startOfMonth, endOfMonth)
         }
     }
 
@@ -156,7 +156,7 @@ extension AcademicScheduleCalendar {
         didSelect date: Date,
         at monthPosition: FSCalendarMonthPosition
     ) {
-        self.clickDate(date)
+        self.dateOnTap(date)
     }
 
     public func calendar(

--- a/Projects/Presentation/Sources/Scene/Schedule/ScheduleViewController.swift
+++ b/Projects/Presentation/Sources/Scene/Schedule/ScheduleViewController.swift
@@ -36,13 +36,13 @@ public class ScheduleViewController: BaseViewController<ScheduleViewModel> {
     private lazy var timeTableView = TimeTableView(frame: viewSize)
     private lazy var academicScheduleView = AcademicScheduleView(
         frame: viewSize,
-        clickYearAndMonth: { year, month in
+        yearAndMonthOnTap: { year, month in
             self.academiScheduleYearAndMonth.accept((
                 year.toString(type: .year),
                 month.toStringEng(type: .fullMonth)
             ))
         },
-        clickDate: { date in
+        dateOnTap: { date in
             self.academicScheduleDate.accept(date.toString(type: .fullDate))
         }
     )

--- a/Projects/Presentation/Sources/Scene/SchoolMeal/SchoolMealViewController.swift
+++ b/Projects/Presentation/Sources/Scene/SchoolMeal/SchoolMealViewController.swift
@@ -16,7 +16,7 @@ public class SchoolMealViewController: BaseViewController<SchoolMealViewModel> {
     private lazy var navigationBar = PiCKMainNavigationBar(view: self)
     private lazy var schoolMealCalendarView = PiCKCalendarView(
         calnedarType: .schoolMealWeek,
-        clickDate: { date in
+        dateOnTap: { date in
             self.loadSchoolMeal(date: date)
         }
     )
@@ -78,11 +78,11 @@ public class SchoolMealViewController: BaseViewController<SchoolMealViewModel> {
                 )
             }.disposed(by: disposeBag)
 
-        schoolMealCalendarView.clickBottomToggleButton
+        schoolMealCalendarView.bottomToggleButtonDidTap
             .bind { [weak self] in
                 let alert = PiCKCalendarAlert(
                     calendarType: .schoolMealMonth,
-                    clickDate: { date in
+                    dateOnTap: { date in
                         self?.loadSchoolMeal(date: date)
                     }
                 )


### PR DESCRIPTION
## 개요
* 홈 리팩토링 및 전체적인 네이밍 수정
## 작업사항
* 홈 리팩토링 및 전체적인 네이밍 수정
## UI

close #172 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
    - 여러 버튼, 탭, 콜백, 이벤트 관련 프로퍼티 및 파라미터 명칭을 "click" 접두사에서 "DidTap", "OnTap" 등으로 일관성 있게 변경하여 가독성과 명확성을 향상시켰습니다.
    - 여러 뷰와 뷰모델에서 입력 구조체(Input)의 프로퍼티 및 내부 변수명을 일관된 스타일로 변경하였습니다.
    - 일부 엔티티 및 DTO에서 학년/반/번호를 하나의 문자열(gcn)로 통합하고, 시간 정보도 하나의 문자열로 단순화하였습니다.
    - 라벨, 버튼 등 UI 요소의 명칭 및 메서드 파라미터명을 실제 데이터 구조에 맞게 변경하였습니다.

- **Style**
    - 코드 내 불필요한 공백 및 중복 코드를 정리하여 가독성을 개선하였습니다.

- **Bug Fixes**
    - 없음

- **New Features**
    - 없음

- **Documentation**
    - 없음

<!-- end of auto-generated comment: release notes by coderabbit.ai -->