### PR TITLE
chore :: [#187] 비밀번호 변경 이메일도 보내기

### DIFF
--- a/Projects/Core/Sources/Steps/PiCKStep.swift
+++ b/Projects/Core/Sources/Steps/PiCKStep.swift
@@ -53,7 +53,7 @@ public enum PiCKStep: Step {
 
     // MARK: ChangePassword
     case changePasswordIsRequired
-    case newPasswordIsRequired(verificationCode: String)
+    case newPasswordIsRequired(acountId: String, verificationCode: String)
 
     // MARK: test
     case testIsRequired

--- a/Projects/Domain/Sources/Parameter/Auth/PasswordChangeRequestParams.swift
+++ b/Projects/Domain/Sources/Parameter/Auth/PasswordChangeRequestParams.swift
@@ -2,13 +2,16 @@ import Foundation
 
 public struct PasswordChangeRequestParams: Encodable {
     public let password: String
+    public let acountId: String
     public let code: String
 
     public init(
         password: String,
+        acountId: String,
         code: String
     ) {
         self.password = password
+        self.acountId = acountId
         self.code = code
     }
 }

--- a/Projects/Flow/Sources/Auth/AuthFlow.swift
+++ b/Projects/Flow/Sources/Auth/AuthFlow.swift
@@ -24,8 +24,8 @@ public class AuthFlow: Flow {
             return navigateToSignin()
         case .changePasswordIsRequired:
             return navigateToPasswordChange()
-        case let .newPasswordIsRequired(verificationCode):
-            return navigateToNewPassword(verificationCode: verificationCode)
+        case let .newPasswordIsRequired(acountId, verificationCode):
+            return navigateToNewPassword(acountId: acountId, verificationCode: verificationCode)
         case .tabIsRequired:
             return .end(forwardToParentFlowWithStep: PiCKStep.tabIsRequired)
         case .testIsRequired:
@@ -63,9 +63,10 @@ public class AuthFlow: Flow {
         ))
     }
 
-    private func navigateToNewPassword(verificationCode: String) -> FlowContributors {
+    private func navigateToNewPassword(acountId: String, verificationCode: String) -> FlowContributors {
         let vc = NewPasswordViewController(viewModel: container.resolve(NewPasswordViewModel.self)!)
 
+        vc.acountId = acountId
         vc.verificationCode = verificationCode
 
         self.rootViewController.pushViewController(vc, animated: true)

--- a/Projects/Presentation/Sources/Scene/AllTab/ChangePassword/NewPassword/NewPasswordViewController.swift
+++ b/Projects/Presentation/Sources/Scene/AllTab/ChangePassword/NewPassword/NewPasswordViewController.swift
@@ -8,6 +8,7 @@ import DesignSystem
 
 public class NewPasswordViewController: BaseViewController<NewPasswordViewModel> {
     public var verificationCode: String = ""
+    public var acountId: String = ""
 
     private let titleLabel = PiCKLabel(
         text: "PiCK 비밀번호 변경하기",
@@ -51,6 +52,7 @@ public class NewPasswordViewController: BaseViewController<NewPasswordViewModel>
         let input = NewPasswordViewModel.Input(
             nextButtonTap: changeButton.rx.tap.asObservable(),
             newPasswordText: newPasswordTextField.rx.text.orEmpty.asObservable(),
+            acountIdText: Observable.just(acountId),
             certificationText: Observable.just(verificationCode)
         )
 

--- a/Projects/Presentation/Sources/Scene/AllTab/ChangePassword/NewPassword/NewPasswordViewModel.swift
+++ b/Projects/Presentation/Sources/Scene/AllTab/ChangePassword/NewPassword/NewPasswordViewModel.swift
@@ -20,6 +20,7 @@ public class NewPasswordViewModel: BaseViewModel, Stepper {
     public struct Input {
         let nextButtonTap: Observable<Void>
         let newPasswordText: Observable<String>
+        let acountIdText: Observable<String>
         let certificationText: Observable<String>
     }
 
@@ -30,21 +31,24 @@ public class NewPasswordViewModel: BaseViewModel, Stepper {
     public func transform(input: Input) -> Output {
         let isFormValid = Observable.combineLatest(
             input.newPasswordText,
+            input.acountIdText,
             input.certificationText
-        ) { password, certification in
-            return !password.isEmpty && !certification.isEmpty
+        ) { password, acountId, certification in
+            return !password.isEmpty && !acountId.isEmpty && !certification.isEmpty
         }
         .distinctUntilChanged()
 
         input.nextButtonTap
             .withLatestFrom(Observable.combineLatest(
                 input.newPasswordText,
+                input.acountIdText,
                 input.certificationText
             ))
-            .flatMapLatest { [weak self] password, certification -> Observable<Step> in
+            .flatMapLatest { [weak self] password, acountId, certification -> Observable<Step> in
                 guard let self = self else { return Observable<Step>.empty() }
                 let params = PasswordChangeRequestParams(
                     password: password,
+                    acountId: acountId,
                     code: certification
                 )
                 return self.passwordChangeUseCase.execute(req: params)


### PR DESCRIPTION
## 개요
비밀번호 변경 이메일도 보내기

## 작업사항
- 비밀번호 변경 request에 acountId 추가

## UI


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 신기능
  * 비밀번호 재설정 과정에서 계정 ID와 인증코드를 함께 입력·전달하도록 지원합니다.
  * 새 비밀번호 화면이 계정 ID를 수신해 다음 단계로 안전하게 전달합니다.
  * 폼 유효성 검사에 계정 ID가 포함되어 입력 정확성이 향상되었습니다.

* 버그 수정
  * 인증코드 확인 중 예외 상황의 안내 문구를 개선하여 오류 인지성과 흐름 안정성을 높였습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->