### PR TITLE
🔗 :: (#204) 비밀번호 변경 화면 전환 및 비밀번호 정규식 수정

### DIFF
--- a/Projects/Flow/Sources/Auth/AuthFlow.swift
+++ b/Projects/Flow/Sources/Auth/AuthFlow.swift
@@ -4,6 +4,7 @@ import Swinject
 
 import Core
 import Presentation
+import DesignSystem
 
 public class AuthFlow: Flow {
     public let container: Container
@@ -26,6 +27,8 @@ public class AuthFlow: Flow {
             return navigateToPasswordChange()
         case let .newPasswordIsRequired(accountId, code):
             return navigateToNewPassword(accountId: accountId, code: code)
+        case let .applyAlertIsRequired(successType, alertType):
+            return presentApplyAlert(successType: successType, alertType: alertType)
         case .tabIsRequired:
             return .end(forwardToParentFlowWithStep: PiCKStep.tabIsRequired)
         case .testIsRequired:
@@ -114,5 +117,18 @@ public class AuthFlow: Flow {
             withNextPresentable: vc,
             withNextStepper: vc.viewModel
         ))
+    }
+
+    private func presentApplyAlert(successType: SuccessType, alertType: DisappearAlertType) -> FlowContributors {
+        let alert = PiCKDisappearAlert(
+            successType: successType,
+            alertType: alertType
+        )
+        alert.modalPresentationStyle = .overFullScreen
+        alert.modalTransitionStyle = .crossDissolve
+
+        self.rootViewController.popToRootViewController(animated: true)
+        self.rootViewController.present(alert, animated: true)
+        return .none
     }
 }

--- a/Projects/Presentation/Sources/Scene/Signup/PasswordSetting/PasswordSettingViewModel.swift
+++ b/Projects/Presentation/Sources/Scene/Signup/PasswordSetting/PasswordSettingViewModel.swift
@@ -29,7 +29,7 @@ public final class PasswordSettingViewModel: BaseViewModel, Stepper {
     public func transform(input: Input) -> Output {
         let errorToastRelay = PublishRelay<String>()
 
-        let passwordRegex = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[!@#$%^&()])[A-Za-z\\d!@#$%^&*()]{8,30}$"
+        let passwordRegex = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[!@#$%^&*()])[A-Za-z\\d!@#$%^&*()]{8,30}$"
 
         let bothFieldsFilled = Observable.combineLatest(
             input.passwordText,

--- a/Projects/Presentation/Sources/Scene/Signup/PasswordSetting/PasswordSettingViewModel.swift
+++ b/Projects/Presentation/Sources/Scene/Signup/PasswordSetting/PasswordSettingViewModel.swift
@@ -29,7 +29,7 @@ public final class PasswordSettingViewModel: BaseViewModel, Stepper {
     public func transform(input: Input) -> Output {
         let errorToastRelay = PublishRelay<String>()
 
-        let passwordRegex = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[!@#$%^&()])[A-Za-z\\d!@#$%^&()]{8,30}$"
+        let passwordRegex = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[!@#$%^&()])[A-Za-z\\d!@#$%^&*()]{8,30}$"
 
         let bothFieldsFilled = Observable.combineLatest(
             input.passwordText,


### PR DESCRIPTION
## 개요
비밀번호 변경 화면 전환 및 비밀번호 정규식 수정

## 작업사항
- Auth Flow에 passwordChange 관련 로직 작성
- 비밀번호 정규식 * 가능하게 수정

## UI
<img width="150" src="https://github.com/user-attachments/assets/66fea040-304e-41ec-b6a0-abcdd9a49be0" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새 기능**
  * 인증 플로우에 새로운 알림 화면이 추가되어 특정 인증 단계에서 사용자에게 적용 안내를 보여줍니다. 앱 내 이동 시 해당 알림이 표시되어 흐름이 더 명확해집니다.

* **개선 사항**
  * 비밀번호 설정 시 특수문자 '*' 입력이 허용되도록 검증 규칙을 업데이트하여 사용 가능한 비밀번호 옵션이 확장되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->