### PR TITLE
🔗 :: (#206) 코드 발송 버튼 클릭 시 1분 비활성화

### DIFF
--- a/Projects/Modules/DesignSystem/Sources/Component/TextField/PiCKTextField.swift
+++ b/Projects/Modules/DesignSystem/Sources/Component/TextField/PiCKTextField.swift
@@ -82,7 +82,7 @@ public class PiCKTextField: BaseTextField {
     }
 
     private let verificationButton = UIButton(type: .system).then {
-        $0.setTitle("인증코드", for: .normal)
+        $0.setTitle("코드 발송", for: .normal)
         $0.setTitleColor(.main900, for: .normal)
         $0.titleLabel?.font = .pickFont(.button2)
         $0.backgroundColor = .main50
@@ -172,6 +172,7 @@ public class PiCKTextField: BaseTextField {
         self.addRightView()
         self.autocapitalizationType = .none
         self.autocorrectionType = .no
+        verificationButton.isEnabled = false
     }
     public override func layout() {
         [
@@ -222,6 +223,11 @@ public class PiCKTextField: BaseTextField {
                 self?.layer.border(color: self?.borderColor, width: 1)
                 self?.errorMessage.accept(nil)
             }.disposed(by: disposeBag)
+
+        self.rx.text.orEmpty
+            .map { !$0.isEmpty }
+            .bind(to: verificationButton.rx.isEnabled)
+            .disposed(by: disposeBag)
 
         self.textHideButton.rx.tap
             .bind { [weak self] in

--- a/Projects/Presentation/Sources/Scene/AllTab/ChangePassword/VerifyEmail/ChangePasswordViewController.swift
+++ b/Projects/Presentation/Sources/Scene/AllTab/ChangePassword/VerifyEmail/ChangePasswordViewController.swift
@@ -56,19 +56,19 @@ public class ChangePasswordViewController: BaseViewController<ChangePasswordView
             .bind(to: nextButton.rx.isEnabled)
             .disposed(by: disposeBag)
 
-        output.verificationButtonText
-            .withUnretained(self)
-            .bind { owner, text in
-                owner.emailTextField.updateVerificationButtonText(text)
-            }
-            .disposed(by: disposeBag)
-
         output.showErrorToast
             .filter { !$0.isEmpty }
             .observe(on: MainScheduler.instance)
             .withUnretained(self)
             .bind { owner, errorMessage in
                 owner.presentErrorToast(message: errorMessage)
+            }
+            .disposed(by: disposeBag)
+
+        output.startTimer
+            .observe(on: MainScheduler.instance)
+            .bind { [weak self] in
+                self?.emailTextField.startTimer()
             }
             .disposed(by: disposeBag)
     }

--- a/Projects/Presentation/Sources/Scene/AllTab/ChangePassword/VerifyEmail/ChangePasswordViewModel.swift
+++ b/Projects/Presentation/Sources/Scene/AllTab/ChangePassword/VerifyEmail/ChangePasswordViewModel.swift
@@ -9,8 +9,7 @@ import Domain
 public class ChangePasswordViewModel: BaseViewModel, Stepper {
     public let steps = PublishRelay<Step>()
     private let disposeBag = DisposeBag()
-    
-    // 🔥 수정: 타이머 시작 신호를 네트워크 성공과 분리
+
     private let startTimerRelay = PublishRelay<Void>()
     private let verificationSuccessRelay = PublishRelay<Void>()
 
@@ -35,7 +34,7 @@ public class ChangePasswordViewModel: BaseViewModel, Stepper {
     public struct Output {
         let isNextButtonEnabled: Observable<Bool>
         let showErrorToast: Observable<String>
-        let startTimer: Observable<Void>  // 🔥 추가: 타이머 시작 신호
+        let startTimer: Observable<Void>
     }
 
     public func transform(input: Input) -> Output {
@@ -49,12 +48,11 @@ public class ChangePasswordViewModel: BaseViewModel, Stepper {
         }
         .distinctUntilChanged()
 
-        // 🔥 수정: 버튼 탭 시 즉시 타이머 시작 신호 발생
         input.verificationButtonTap
             .withLatestFrom(input.emailText)
-            .filter { !$0.isEmpty }  // 이메일이 비어있지 않을 때만
+            .filter { !$0.isEmpty }
             .do(onNext: { [weak self] _ in
-                self?.startTimerRelay.accept(())  // 즉시 타이머 시작 신호
+                self?.startTimerRelay.accept(())
             })
             .flatMapLatest { [weak self] email -> Observable<Void> in
                 guard let self = self else { return .empty() }
@@ -81,7 +79,7 @@ public class ChangePasswordViewModel: BaseViewModel, Stepper {
         return Output(
             isNextButtonEnabled: isFormValid,
             showErrorToast: errorToastRelay.asObservable(),
-            startTimer: startTimerRelay.asObservable()  // 🔥 추가
+            startTimer: startTimerRelay.asObservable()
         )
     }
 

--- a/Projects/Presentation/Sources/Scene/Signup/VerifyEmailSetting/VerifyEmailReactor.swift
+++ b/Projects/Presentation/Sources/Scene/Signup/VerifyEmailSetting/VerifyEmailReactor.swift
@@ -37,8 +37,6 @@ public final class VerifyEmailReactor: BaseReactor {
         case certificationError(String)
         case errorReset
         case isNextButtonEnabled(Bool)
-        case updateVerificationButtonText(String)
-        case verificationCodeSent
         case verificationSuccess
         case navigateToPasswordSetting
         case showErrorToast(String)
@@ -50,7 +48,6 @@ public final class VerifyEmailReactor: BaseReactor {
         var emailErrorDescription: String = ""
         var certificationErrorDescription: String = ""
         var isNextButtonEnabled: Bool = false
-        var verificationButtonText: String = "인증코드"
         var errorToastMessage: String = ""
     }
 }
@@ -72,7 +69,6 @@ extension VerifyEmailReactor {
             ])
         case .verificationButtonDidTap:
             return .concat([
-                .just(.updateVerificationButtonText("재발송")),
                 sendVerificationCode(email: self.currentState.email)
             ])
         case .nextButtonDidTap:
@@ -101,10 +97,6 @@ extension VerifyEmailReactor {
             newState.errorToastMessage = ""
         case .isNextButtonEnabled(let enabled):
             newState.isNextButtonEnabled = enabled
-        case .updateVerificationButtonText(let text):
-            newState.verificationButtonText = text
-        case .verificationCodeSent:
-            newState.verificationButtonText = "재발송"
         case .verificationSuccess:
             break
         case .navigateToPasswordSetting:
@@ -126,7 +118,7 @@ extension VerifyEmailReactor {
                 title: "회원가입 인증"
             )
         )
-        .andThen(.just(.verificationCodeSent))
+        .andThen(.just(.verificationSuccess))
         .catch { error in
             if let nsError = error as NSError? {
                 if let message = nsError.userInfo[NSLocalizedDescriptionKey] as? String, !message.isEmpty {

--- a/Projects/Presentation/Sources/Scene/Signup/VerifyEmailSetting/VerifyEmailViewController.swift
+++ b/Projects/Presentation/Sources/Scene/Signup/VerifyEmailSetting/VerifyEmailViewController.swift
@@ -56,8 +56,12 @@ public class VerifyEmailViewController: BaseReactorViewController<VerifyEmailRea
             .drive(reactor.action)
             .disposed(by: disposeBag)
 
-        emailTextField.verificationButtonTapped.asDriver(onErrorJustReturn: ())
+        emailTextField.verificationButtonTapped
+            .do(onNext: { [weak self] in
+                self?.emailTextField.startTimer()
+            })
             .map { VerifyEmailReactor.Action.verificationButtonDidTap }
+            .asDriver(onErrorDriveWith: .empty())
             .drive(reactor.action)
             .disposed(by: disposeBag)
 
@@ -75,15 +79,6 @@ public class VerifyEmailViewController: BaseReactorViewController<VerifyEmailRea
             .withUnretained(self)
             .bind { owner, isEnabled in
                 owner.nextButton.isEnabled = isEnabled
-            }
-            .disposed(by: disposeBag)
-
-        reactor.state
-            .map { $0.verificationButtonText }
-            .distinctUntilChanged()
-            .withUnretained(self)
-            .bind { owner, buttonText in
-                owner.emailTextField.updateVerificationButtonText(buttonText)
             }
             .disposed(by: disposeBag)
 


### PR DESCRIPTION
## 개요
코드 발송 버튼 클릭 시 1분 비활성화

## 작업사항
- PiCKTextfield에 코드 발송 버튼 클릭 시 1분 비활성화
- Text Empty 시 코드 발송 버튼 비활성화

## UI
<img width="150" src="https://github.com/user-attachments/assets/f0f7386e-5e1e-4e36-9fad-d5761f0a36e9" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 이메일/인증 입력 필드에 60초 카운트다운 타이머 추가 — 발송 버튼이 타이머 동안 비활성화되고 남은 시간을 MM:SS로 표시
  * 버튼 텍스트 초기값을 “코드 발송”으로 변경

* **동작 변경**
  * 버튼 활성화 로직을 입력 유무와 타이머 상태 기반으로 통합
  * 화면 전환·해제 시 타이머 자동 정지 및 포그라운드 복귀 시 표시 갱신 보장

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->