### PR TITLE
🔗 :: (#210) socket access token 앞에 Bearer

### DIFF
--- a/Projects/Data/Sources/DataSource/HomeDataSource.swift
+++ b/Projects/Data/Sources/DataSource/HomeDataSource.swift
@@ -28,7 +28,7 @@ class HomeDataSourceImpl: WebSocketDelegate, HomeDataSource {
         let url = URL(string: "\(URLUtil.socketBaseURL)/main")
         var request = URLRequest(url: url!)
         request.timeoutInterval = 5
-        request.setValue("\(keychain.load(type: .accessToken))", forHTTPHeaderField: "Authorization")
+        request.setValue("Bearer \(keychain.load(type: .accessToken))", forHTTPHeaderField: "Authorization")
         socket = WebSocket(request: request)
         socket?.delegate = self
         socket?.connect()


### PR DESCRIPTION
## 개요
socket access token 앞에 Bearer

## 작업사항
- socket access token 앞에 Bearer 붙임

## UI


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * WebSocket 연결 시 인증 헤더 형식이 개선되어 인증 신뢰성이 향상되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->