### PR TITLE
🔗 :: (#235) 주말 급식 상태 받아 나타내기

### DIFF
--- a/Projects/Flow/Sources/Home/HomeFlow.swift
+++ b/Projects/Flow/Sources/Home/HomeFlow.swift
@@ -29,6 +29,8 @@ public class HomeFlow: Flow {
             return navigateToNotice()
         case .noticeDetailIsRequired(let id):
             return navigateToNoticeDetail(id: id)
+        case .weekendMealApplyIsRequired:
+            return navigateToWeekendMealApply()
         default:
             return .none
         }
@@ -75,6 +77,14 @@ public class HomeFlow: Flow {
     private func navigateToNoticeDetail(id: UUID) -> FlowContributors {
         let vc = container.resolve(NoticeDetailViewController.self)!
         vc.id = id
+
+        vc.hidesBottomBarWhenPushed = true
+        self.rootViewController.pushViewController(vc, animated: true)
+        return .none
+    }
+
+    private func navigateToWeekendMealApply() -> FlowContributors {
+        let vc = container.resolve(WeekendMealApplyViewController.self)!
 
         vc.hidesBottomBarWhenPushed = true
         self.rootViewController.pushViewController(vc, animated: true)

--- a/Projects/Flow/Sources/Home/HomeFlow.swift
+++ b/Projects/Flow/Sources/Home/HomeFlow.swift
@@ -88,7 +88,10 @@ public class HomeFlow: Flow {
 
         vc.hidesBottomBarWhenPushed = true
         self.rootViewController.pushViewController(vc, animated: true)
-        return .none
+        return .one(flowContributor: .contribute(
+            withNextPresentable: vc,
+            withNextStepper: vc.viewModel
+        ))
     }
 
 }

--- a/Projects/Flow/Sources/Home/HomeFlow.swift
+++ b/Projects/Flow/Sources/Home/HomeFlow.swift
@@ -4,6 +4,7 @@ import RxFlow
 import Swinject
 
 import Core
+import DesignSystem
 import Presentation
 
 public class HomeFlow: Flow {
@@ -31,6 +32,8 @@ public class HomeFlow: Flow {
             return navigateToNoticeDetail(id: id)
         case .weekendMealApplyIsRequired:
             return navigateToWeekendMealApply()
+        case let .applyAlertIsRequired(successType, alertType):
+            return presentApplyAlert(successType: successType, alertType: alertType)
         default:
             return .none
         }
@@ -92,6 +95,22 @@ public class HomeFlow: Flow {
             withNextPresentable: vc,
             withNextStepper: vc.viewModel
         ))
+    }
+
+    private func presentApplyAlert(successType: SuccessType, alertType: DisappearAlertType) -> FlowContributors {
+        let alert = PiCKDisappearAlert(
+            successType: successType,
+            alertType: alertType
+        )
+        alert.modalPresentationStyle = .overFullScreen
+        alert.modalTransitionStyle = .crossDissolve
+
+        if successType == .success {
+            self.rootViewController.tabBarController?.selectedIndex = 0
+        }
+        self.rootViewController.popToRootViewController(animated: true)
+        self.rootViewController.present(alert, animated: true)
+        return .none
     }
 
 }

--- a/Projects/Presentation/Sources/Scene/Apply/Component/WeekendMeal/WeekendMealApplyView.swift
+++ b/Projects/Presentation/Sources/Scene/Apply/Component/WeekendMeal/WeekendMealApplyView.swift
@@ -42,9 +42,7 @@ public class WeekendMealApplyView: BaseView {
             self.currnetMonthWeekendMealApplyLabel.changePointColor(targetString: "\(statusText)", color: .main500)
         }
 
-        self.buttonStackView.isHidden = !isApplicable
-        self.applyState.accept(status)
-        self.weekendMealStatusButtonDidTap(status ? .ok : .no)
+        buttonStackView.isHidden = !isApplicable
     }
 
     public init(
@@ -108,6 +106,10 @@ public class WeekendMealApplyView: BaseView {
         notApplyButton.isSelected = !applyState.value
 
         weekendMealStatusButtonDidTap(applyState.value == true ? .ok : .no)
+    }
+
+    public func setInitialStatus(_ status: WeekendMealType) {
+        applyState.accept(status == .ok)
     }
 
 }

--- a/Projects/Presentation/Sources/Scene/Apply/WeekendMeal/WeekendMealApplyViewController.swift
+++ b/Projects/Presentation/Sources/Scene/Apply/WeekendMeal/WeekendMealApplyViewController.swift
@@ -53,6 +53,23 @@ public class WeekendMealApplyViewController: BaseViewController<WeekendMealApply
                 )
                 self?.saveButton.isHidden = !data.isApplicable
             }.disposed(by: disposeBag)
+
+        output.weekendMealStatus
+            .emit(onNext: { [weak self] status in
+                self?.weekendMealApplyView.setInitialStatus(status)
+            })
+            .disposed(by: disposeBag)
+
+        output.weekendMealApplicationPeriod
+            .emit(onNext: { [weak self] data in
+                self?.weekendMealApplyView.setup(
+                    status: true,
+                    isApplicable: data.isApplicable,
+                    month: data.month ?? 0
+                )
+                self?.saveButton.isHidden = !data.isApplicable
+            })
+            .disposed(by: disposeBag)
     }
 
     public override func addView() {

--- a/Projects/Presentation/Sources/Scene/Home/HomeViewController.swift
+++ b/Projects/Presentation/Sources/Scene/Home/HomeViewController.swift
@@ -15,6 +15,7 @@ public class HomeViewController: BaseViewController<HomeViewModel> {
     private var outingPassType = PublishRelay<OutingType>()
 
     private var noticeButtonDidTapRelay = PublishRelay<UUID>()
+    private var weekendMealPeriodHeaderViewDidTapRelay = PublishRelay<Void>()
 
     private let todayDate = Date()
 
@@ -46,8 +47,12 @@ public class HomeViewController: BaseViewController<HomeViewModel> {
 
     private lazy var navigationBar = PiCKMainNavigationBar(view: self)
 
-    private let weekendMealPeriodHeaderView = WeekendMealPeriodHeaderView().then {
+    private let weekendMealPeriodTapGesture = UITapGestureRecognizer()
+
+    private lazy var weekendMealPeriodHeaderView = WeekendMealPeriodHeaderView().then {
         $0.isHidden = true
+        $0.addGestureRecognizer(weekendMealPeriodTapGesture)
+        $0.isUserInteractionEnabled = true
     }
     private lazy var profileView = PiCKProfileView()
     private let passHeaderView = HomePassHeaderView().then {
@@ -135,7 +140,8 @@ public class HomeViewController: BaseViewController<HomeViewModel> {
             outingPassDidTap: passHeaderView.buttonTap.asObservable(),
             outingPassType: outingPassType.asObservable(),
             viewMoreNoticeButtonDidTap: viewMoreButton.rx.tap.asObservable(),
-            noticeDidSelect: noticeButtonDidTapRelay.asObservable()
+            noticeDidSelect: noticeButtonDidTapRelay.asObservable(),
+            weekendMealPeriodHeaderViewDidTap: weekendMealPeriodHeaderViewDidTapRelay.asObservable()
         )
         let output = viewModel.transform(input: input)
 
@@ -219,6 +225,11 @@ public class HomeViewController: BaseViewController<HomeViewModel> {
             .bind { owner, data in
                 owner.noticeButtonDidTapRelay.accept(data.id)
             }.disposed(by: disposeBag)
+
+        weekendMealPeriodTapGesture.rx.event
+            .map { _ in () }
+            .bind(to: weekendMealPeriodHeaderViewDidTapRelay)
+            .disposed(by: disposeBag)
 
         output.outingPassData.asObservable()
             .withUnretained(self)

--- a/Projects/Presentation/Sources/Scene/Home/HomeViewModel.swift
+++ b/Projects/Presentation/Sources/Scene/Home/HomeViewModel.swift
@@ -56,6 +56,7 @@ public class HomeViewModel: BaseViewModel, Stepper {
         let outingPassType: Observable<OutingType>
         let viewMoreNoticeButtonDidTap: Observable<Void>
         let noticeDidSelect: Observable<UUID>
+        let weekendMealPeriodHeaderViewDidTap: Observable<Void>
     }
     public struct Output {
         let viewMode: Signal<HomeViewType>
@@ -220,6 +221,11 @@ public class HomeViewModel: BaseViewModel, Stepper {
             .map { id in
                 PiCKStep.noticeDetailIsRequired(id: id)
             }
+            .bind(to: steps)
+            .disposed(by: disposeBag)
+
+        input.weekendMealPeriodHeaderViewDidTap
+            .map { PiCKStep.weekendMealApplyIsRequired }
             .bind(to: steps)
             .disposed(by: disposeBag)
 


### PR DESCRIPTION
## 개요
주말 급식 상태 받아 나타내기

## 작업사항
- 화면에 들어왔을 때 status를 받아 현재 상태 업데이트 시키기
-> 사용자가 신청 기간에도 자신의 상태를 알 수 있도록 변경
- 메인화면에 뜨는 주말 급식 기간 공지 클릭 시 주말 급식 신청 화면으로 이동

## UI


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 홈 화면의 주말식사 기간 헤더를 탭하면 주말식사 신청 화면으로 이동할 수 있습니다.
  * 주말식사 신청 화면 흐름이 추가되어 접근성이 향상되었습니다.

* **UI 변경**
  * 신청 화면에서 저장 버튼 표시가 입력에 따라 더 명확히 갱신됩니다.
  * 적용 불가 상태일 때 라벨 텍스트 동작은 기존대로 유지됩니다.

* **Refactor**
  * 초기 상태 설정과 화면 업데이트 흐름을 분리해 상태 적용 방식이 명확해졌습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->