### PR TITLE
🔗 :: (#239) 자습감독 조회 시 mealDate 대신 현재 날짜 사용하도록 수정 

### DIFF
--- a/Projects/Presentation/Sources/Scene/Home/HomeViewController.swift
+++ b/Projects/Presentation/Sources/Scene/Home/HomeViewController.swift
@@ -134,7 +134,8 @@ public class HomeViewController: BaseViewController<HomeViewModel> {
 
     public override func bind() {
         let input = HomeViewModel.Input(
-            todayDate: todayDate.mealDate.toString(type: .fullDate),
+            todayDate: todayDate.toString(type: .fullDate),
+            schoolMealDate: todayDate.mealDate.toString(type: .fullDate),
             viewWillAppear: viewWillAppearRelay.asObservable(),
             alertButtonDidTap: navigationBar.alertButtonTap.asObservable(),
             outingPassDidTap: passHeaderView.buttonTap.asObservable(),

--- a/Projects/Presentation/Sources/Scene/Home/HomeViewModel.swift
+++ b/Projects/Presentation/Sources/Scene/Home/HomeViewModel.swift
@@ -50,6 +50,7 @@ public class HomeViewModel: BaseViewModel, Stepper {
 
     public struct Input {
         let todayDate: String
+        let schoolMealDate: String
         let viewWillAppear: Observable<Void>
         let alertButtonDidTap: Observable<Void>
         let outingPassDidTap: Observable<Void>
@@ -141,7 +142,7 @@ public class HomeViewModel: BaseViewModel, Stepper {
 
         input.viewWillAppear
             .flatMap {
-                self.schoolMealUseCase.execute(date: input.todayDate)
+                self.schoolMealUseCase.execute(date: input.schoolMealDate)
                     .catch {
                         print($0.localizedDescription)
                         return .never()


### PR DESCRIPTION
## 개요
- 저녁 7시 이후 자습감독 정보가 다음 날짜 데이터로 표시되는 문제를 수정했습니다.
## 작업사항
- Input 파라미터를 todayDate(실제 날짜)와 schoolMealDate(급식용 날짜)로 분리
## UI


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**버그 수정**
  * 학교 급식 정보의 날짜 처리 로직이 개선되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->