### PR TITLE
🔗 :: (#245) 에러 문구 수정

### DIFF
--- a/Projects/Domain/Sources/Error/PiCKError.swift
+++ b/Projects/Domain/Sources/Error/PiCKError.swift
@@ -12,7 +12,7 @@ extension PiCKError: LocalizedError {
         case let .error(message, _):
             return message
         case .deploymentPipelineError:
-            return "배포 파이프라인 실행 중 오류가 발생했습니다"
+            return "스퀘어가 터졌습니다"
         case .serverError:
             return "PiCK 서버에 오류가 발생했습니다"
         }


### PR DESCRIPTION
## 개요
배포 파이프라인 실행 중 오류가 발생한 상황에서의 에러 문구 수정

## 작업사항
"스퀘어가 터졌습니다"로 수정

## UI
<img width="145" height="314" alt="Simulator Screenshot - iPhone 17 Pro - 2026-04-13 at 18 06 36" src="https://github.com/user-attachments/assets/546ce54f-9b7c-4afd-b3f6-9a2da289d712" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Bug Fixes**
  * 배포 파이프라인 오류 메시지를 업데이트했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->